### PR TITLE
remove s3-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,6 @@ Options:
   -output string      Output file, "-" for stdout (default "-")
   -exclude string     Exclude pattern (can be specified multiple times)
   -s3-bucket string   S3 bucket name
-  -s3-key string      Custom S3 key path (rarely needed, use app-name instead)
   -s3-region string   AWS region
   -base-path string   S3 base path (default "development")
   -app-name string    Application name (creates path: {base-path}/{app-name}/manifest.json)
@@ -316,10 +315,9 @@ Verify file integrity.
 Options:
   -manifest string    Manifest file path
   -s3-bucket string   S3 bucket name
-  -s3-key string      S3 key path (alternative to app-name for custom paths)
   -s3-region string   AWS region
   -base-path string   S3 base path (default "development")
-  -app-name string    Application name for automatic S3 path
+  -app-name string    Application name (reads from: {base-path}/{app-name}/manifest.json)
   -target string      Target directory to verify (default ".")
   -format string      Output format: text, json (default "text")
 ```

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -492,13 +492,13 @@ func TestCLIInvalidCommands(t *testing.T) {
 			errMsg:   "either -manifest or -s3-bucket must be specified",
 		},
 		{
-			name: "s3 without key or app-name",
+			name: "s3 without app-name",
 			args: []string{"kekkai", "generate",
 				"--target", ".",
 				"--s3-bucket", "test-bucket",
 			},
 			wantExit: ExitCodeFail,
-			errMsg:   "Either -s3-key or -app-name must be specified",
+			errMsg:   "-app-name must be specified with -s3-bucket",
 		},
 	}
 

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -44,8 +44,8 @@ func NewS3Storage(bucket string, region string) (*S3Storage, error) {
 	}, nil
 }
 
-// Upload uploads a manifest to S3
-func (s *S3Storage) Upload(key string, m *manifest.Manifest) error {
+// upload uploads a manifest to S3 (internal use only)
+func (s *S3Storage) upload(key string, m *manifest.Manifest) error {
 	// Marshal manifest to JSON
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -73,8 +73,8 @@ func (s *S3Storage) Upload(key string, m *manifest.Manifest) error {
 	return nil
 }
 
-// Download downloads a manifest from S3
-func (s *S3Storage) Download(key string) (*manifest.Manifest, error) {
+// download downloads a manifest from S3 (internal use only)
+func (s *S3Storage) download(key string) (*manifest.Manifest, error) {
 	// Get object from S3
 	result, err := s.client.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
@@ -103,18 +103,18 @@ func (s *S3Storage) UploadWithVersioning(basePath string, appName string, m *man
 	key := fmt.Sprintf("%s/%s/manifest.json", basePath, appName)
 
 	// Upload manifest
-	if err := s.Upload(key, m); err != nil {
+	if err := s.upload(key, m); err != nil {
 		return "", err
 	}
 
 	return key, nil
 }
 
-// DownloadLatest downloads the latest manifest for an app
-func (s *S3Storage) DownloadLatest(basePath string, appName string) (*manifest.Manifest, error) {
-	// Direct download from the single manifest file
+// DownloadManifest downloads the manifest for an app
+func (s *S3Storage) DownloadManifest(basePath string, appName string) (*manifest.Manifest, error) {
+	// Download from the single manifest file
 	key := fmt.Sprintf("%s/%s/manifest.json", basePath, appName)
-	return s.Download(key)
+	return s.download(key)
 }
 
 // List lists all versions of the manifest (requires S3 versioning enabled)


### PR DESCRIPTION
This pull request simplifies the S3 integration by removing the `-s3-key` option and requiring the use of `-app-name` for S3 operations. This change streamlines the CLI interface and reduces potential confusion about which S3 pathing mechanism to use. Related code and documentation have been updated to reflect this change, and internal S3 methods have been refactored for clarity.

**CLI and S3 Usage Simplification:**

* Removed the `-s3-key` option from both the `generate` and `verify` commands. Now, only `-app-name` is used to specify the S3 path, and it is required when using `-s3-bucket`. Corresponding error messages and documentation have been updated to reflect this requirement. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL96) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL110) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL150-R155) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL197) [[5]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL211) [[6]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL241-R237) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L319-R320) [[9]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL495-R501)

**Internal S3 API Refactoring:**

* Made `upload` and `download` internal methods (lowercase) in `s3.go`, clarifying their intended usage and limiting their exposure. [[1]](diffhunk://#diff-f22ce1d0b5fcda54bebe7decd2c96f5f687ca1ff489aabe06c1fda8f8e9bfa04L47-R48) [[2]](diffhunk://#diff-f22ce1d0b5fcda54bebe7decd2c96f5f687ca1ff489aabe06c1fda8f8e9bfa04L76-R77)
* Renamed `DownloadLatest` to `DownloadManifest` and updated its implementation to use the new internal method, aligning with the new S3 usage pattern.

These changes make the CLI easier to use and maintain, and clarify how S3 paths are managed throughout the codebase.