### PR TITLE
remove ListBucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,9 @@ For production server (read-only):
     {
       "Effect": "Allow",
       "Action": [
-        "s3:GetObject",
-        "s3:ListBucket"
+        "s3:GetObject"
       ],
-      "Resource": [
-        "arn:aws:s3:::my-manifests",
-        "arn:aws:s3:::my-manifests/*"
-      ]
+      "Resource": "arn:aws:s3:::my-manifests/*"
     }
   ]
 }


### PR DESCRIPTION
This pull request primarily simplifies the S3 storage implementation by removing several unused or unnecessary methods and updating the associated AWS S3 permissions in the documentation. The changes make the codebase easier to maintain and clarify the minimal permissions required for production.

**S3 Storage Implementation Cleanup:**

* Removed the following unused methods from `internal/storage/s3.go`: `List`, `Exists`, `GetMetadata`, and `Reader`, which were related to advanced S3 operations such as listing object versions, checking existence, retrieving metadata, and streaming objects.
* Cleaned up imports in `internal/storage/s3.go` by removing the unused `io` package.

**Documentation Update:**

* Updated the S3 IAM policy example in `README.md` to remove the `s3:ListBucket` action and restrict the `Resource` to `arn:aws:s3:::my-manifests/*`, reflecting the reduced set of required permissions.