### PR TITLE
Use all available CPUs for hash calculator by runtime.GOMAXPROCS

### DIFF
--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -35,8 +36,8 @@ type Calculator struct {
 // NewCalculator creates a new hash calculator
 func NewCalculator() *Calculator {
 	return &Calculator{
-		numWorkers: 4,           // Default to 4 workers
-		bufferSize: 1024 * 1024, // 1MB buffer
+		numWorkers: runtime.GOMAXPROCS(0), // Use all available CPUs
+		bufferSize: 1024 * 1024,           // 1MB buffer
 	}
 }
 


### PR DESCRIPTION
This pull request updates the hash calculator to better utilize system resources by dynamically setting the number of worker goroutines based on the available CPU cores, instead of using a fixed value.

Performance and resource utilization improvements:

* [`internal/hash/hash.go`](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L38-R39): Changed the default number of workers in the `Calculator` from a fixed value of 4 to `runtime.GOMAXPROCS(0)`, ensuring the calculator uses all available CPUs for improved parallel performance.
* [`internal/hash/hash.go`](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8R10): Added an import for the `runtime` package to support the dynamic worker count.