### PR TITLE
Refine symlink tracking to detect target changes and replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,19 @@ Traditional tools like `tar` or file sync utilities (e.g., `rsync`) include meta
    - Only exclude server-generated files (logs, cache, uploads, NFS mounts)
    - Application dependencies (vendor, node_modules) are monitored as they're part of the deployment
 
-3. **Secure Hash Storage with S3**
+3. **Symlink Security**
+   - Tracks symbolic links with their target paths
+   - Detects when symlinks are modified to point to different targets
+   - Detects when regular files are replaced with symlinks (and vice versa)
+   - Prevents attackers from hiding malicious changes through symlink manipulation
+
+4. **Secure Hash Storage with S3**
    - Deploy servers have write-only access
    - Application servers have read-only access
    - Even if compromised, attackers cannot modify stored hashes
    - Local file output available for testing
 
-4. **Tamper-Resistant Distribution**
+5. **Tamper-Resistant Distribution**
    - Single Go binary with minimal dependencies
    - Recommended to run with restricted permissions
    - Configuration should be read from S3 or managed paths, not local files


### PR DESCRIPTION
This pull request introduces comprehensive symlink tracking and security to the file integrity system. It changes the way symlinks are handled: instead of skipping them, the system now records their presence, target paths, and detects manipulations such as target changes or file/symlink replacements. The update is reflected in both the implementation and the documentation, and is thoroughly tested with new and updated test cases.

**Symlink tracking and security:**

* Updated the `FileInfo` struct in `internal/hash/hash.go` to include `IsSymlink` and `LinkTarget` fields, allowing the system to record whether a file is a symlink and what its target is.
* Changed the file collection and hash calculation logic in `internal/hash/hash.go` to no longer skip symlinks, but instead hash their target paths and include them in the manifest. [[1]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L93-L98) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L133-R173)

**Testing and validation:**

* Added a new test `TestSymlinkSecurity` in `internal/hash/hash_test.go` to ensure the system detects symlink manipulations, including changes to symlink targets and replacements between symlinks and regular files.
* Updated the existing `TestSymlinkHandling` test to verify that symlinks are now tracked (not skipped) and their targets are correctly recorded.

**Documentation:**

* Updated the `README.md` to describe the new symlink security features, including detection of symlink modifications and prevention of attacks via symlink manipulation.