### PR TITLE
use wg.Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/kekkai
 
-go 1.24
+go 1.25.0
 
 require github.com/aws/aws-sdk-go v1.55.8
 

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -122,9 +122,7 @@ func (c *Calculator) calculateFileHashes(rootDir string, files []string) ([]File
 
 	// Start workers
 	for i := 0; i < c.numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for path := range jobs {
 				info, err := os.Lstat(path) // Use Lstat to get symlink info
 				if err != nil {
@@ -171,7 +169,7 @@ func (c *Calculator) calculateFileHashes(rootDir string, files []string) ([]File
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	// Send jobs


### PR DESCRIPTION
This pull request updates the Go version for the project and refactors the worker goroutine management in the `calculateFileHashes` function to use the `WaitGroup.Go` method, which simplifies goroutine error handling and management.

Updates and dependency changes:

* Updated the Go version in `go.mod` from `1.24` to `1.25.0`, ensuring compatibility with the latest language features and improvements.

Codebase improvements (Concurrency and Goroutine Management):

* Refactored the worker goroutine spawning in `internal/hash/hash.go` to use `wg.Go` instead of manually managing `wg.Add(1)` and `wg.Done()`, streamlining concurrency management and improving code readability. [[1]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L125-R125) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L174-R172)