### PR TITLE
Remove redundant s3:PutObjectAcl permission from IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ For deployment server (write access):
     {
       "Effect": "Allow",
       "Action": [
-        "s3:PutObject",
-        "s3:PutObjectAcl"
+        "s3:PutObject"
       ],
       "Resource": "arn:aws:s3:::my-manifests/*"
     }


### PR DESCRIPTION
This pull request makes a minor update to the deployment server's AWS permissions example in the `README.md` file. Specifically, it removes the unnecessary `s3:PutObjectAcl` permission, leaving only `s3:PutObject` for uploading objects to S3.