### PR TITLE
Remove mention of automatic history and clarify optional versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ kekkai generate \
 
 #### Using S3 Storage
 
-Kekkai stores manifests in S3 for secure, centralized management. Each deployment updates the same `manifest.json` file, with S3's built-in versioning maintaining the history.
+Kekkai stores manifests in S3 for secure, centralized management. Each deployment updates the same `manifest.json` file.
 
 ```bash
 # For production deployment (must explicitly specify --base-path)
@@ -118,7 +118,6 @@ kekkai verify \
 **Benefits:**
 - **Lower S3 costs** - Minimal S3 operations
 - **Clean structure** - One manifest file per application
-- **Automatic history** - S3 versioning tracks all changes
 
 #### Monitoring Integration
 
@@ -224,10 +223,10 @@ For production server (read-only):
 
 ### S3 Bucket Setup
 
-**Important:** S3 versioning must be enabled for history tracking.
+**Recommended:** Enable S3 versioning to maintain history of manifest changes.
 
 ```bash
-# Enable versioning for history tracking
+# Optional: Enable versioning for history tracking
 aws s3api put-bucket-versioning \
   --bucket my-manifests \
   --versioning-configuration Status=Enabled


### PR DESCRIPTION
This pull request updates the `README.md` documentation to clarify the role of S3 versioning in managing manifest history. The changes make it clear that enabling S3 versioning is recommended but not strictly required, and they remove references to automatic history tracking as a default behavior.

Documentation updates regarding S3 versioning:

* Changed the S3 storage section to remove the statement that S3's built-in versioning automatically maintains history, clarifying that deployments update the same `manifest.json` file.
* Removed the claim that S3 versioning "automatically" tracks all changes from the list of benefits in the S3 usage section.
* Updated the S3 bucket setup instructions to recommend (rather than require) enabling S3 versioning for history tracking, and marked the versioning command as optional.