### PR TITLE
Optimize slice allocations with pre-defined capacities

### DIFF
--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -80,7 +80,7 @@ func (c *Calculator) CalculateDirectory(rootDir string, excludes []string) (*Res
 
 // collectFiles walks the directory and collects files based on patterns
 func (c *Calculator) collectFiles(rootDir string, excludes []string) ([]string, error) {
-	var files []string
+	files := make([]string, 0, 50) // Start with capacity for 50 files
 
 	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -186,7 +186,7 @@ func (c *Calculator) calculateFileHashes(rootDir string, files []string) ([]File
 	}()
 
 	// Collect results
-	var fileInfos []FileInfo
+	fileInfos := make([]FileInfo, 0, len(files)) // Pre-allocate based on file count
 	for result := range results {
 		fileInfos = append(fileInfos, result)
 	}
@@ -319,7 +319,7 @@ func VerifyIntegrity(manifest *Result, targetDir string) error {
 		currentMap[f.Path] = f.Hash
 	}
 
-	var issues []string
+	issues := make([]string, 0, 10) // Start with capacity for 10 issues
 
 	// Check for modified or deleted files
 	for path, expectedHash := range manifestMap {
@@ -378,7 +378,7 @@ func VerifyIntegrityWithPatterns(manifest *Result, targetDir string, excludes []
 		currentMap[f.Path] = f.Hash
 	}
 
-	var issues []string
+	issues := make([]string, 0, 10) // Start with capacity for 10 issues
 
 	// Check for modified or deleted files
 	for path, expectedHash := range manifestMap {


### PR DESCRIPTION
This pull request makes minor performance improvements to the `internal/hash/hash.go` file by pre-allocating slices with an estimated capacity in several functions. This helps reduce memory allocations and can improve efficiency when dealing with large numbers of files.

Performance optimizations:

* Pre-allocated the `files` slice with a capacity of 50 in the `collectFiles` function to reduce allocations when collecting file paths.
* Pre-allocated the `fileInfos` slice based on the number of files in the `calculateFileHashes` function to optimize memory usage when storing file information.
* Pre-allocated the `issues` slice with a capacity of 10 in both the `VerifyIntegrity` and `VerifyIntegrityWithPatterns` functions to minimize reallocations when tracking integrity issues. [[1]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L322-R322) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L381-R381)