### PR TITLE
update Go version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.24.6
+          go-version-input: 1.25.0
           go-package: ./...


### PR DESCRIPTION
This pull request updates the Go version used by the `govulncheck` security workflow to ensure compatibility and access to the latest features and security fixes.

- **Security workflow update:**
  * [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL22-R22): Updated the `govulncheck` action to use Go version `1.25.0` instead of `1.24.6`.