### PR TITLE
Add regex manager for go-version in GitHub workflow security.yml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,18 @@
   "extends": [
     "config:recommended"
   ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        ".github/workflows/security.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    }
+  ],
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to add automated management of Go version updates in the GitHub Actions workflow. The new configuration allows Renovate to detect and update the Go version specified in the `.github/workflows/security.yml` file.

Renovate configuration enhancements:

* Added a `regexManager` to `renovate.json` to automatically detect and update the Go version in `.github/workflows/security.yml` using a regex pattern for `go-version-input`.