### PR TITLE
Optimize hash file computation by reusing hasher

### DIFF
--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -1,6 +1,7 @@
 package hash
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,13 +50,15 @@ func TestCalculateFileHash(t *testing.T) {
 
 			// Calculate hash
 			calc := NewCalculator()
-			hash, err := calc.hashFile(tmpfile.Name())
+			hasher := sha256.New()
+			buf := make([]byte, calc.bufferSize)
+			hash, err := calc.hashFileWithHasher(tmpfile.Name(), hasher, buf)
 			if err != nil {
-				t.Fatalf("hashFile() error = %v", err)
+				t.Fatalf("hashFileWithHasher() error = %v", err)
 			}
 
 			if hash != tt.expected {
-				t.Errorf("hashFile() = %v, want %v", hash, tt.expected)
+				t.Errorf("hashFileWithHasher() = %v, want %v", hash, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request optimizes the file hashing process by reusing hashers and buffers within worker goroutines, reducing allocations and improving performance. It also updates the hashing function signatures and related tests to support this change.

**Hashing performance and code improvements:**

* Refactored the worker loop in `Calculator.calculateFileHashes` to create and reuse a single `hasher` and buffer per worker, instead of allocating new ones for each file. This reduces memory allocations and improves hashing efficiency.
* Updated symlink hashing to reuse the worker's `hasher` by calling `hasher.Reset()` instead of allocating a new one each time.
* Changed regular file hashing to use the new `hashFileWithHasher` method, passing in the reusable `hasher` and buffer.
* Replaced the old `hashFile` method with `hashFileWithHasher`, which now takes a `hash.Hash` and buffer as arguments and resets the hasher before use. This enables hasher/buffer reuse and further reduces allocations. [[1]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L206-R219) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8R7)

**Test updates:**

* Updated the `TestCalculateFileHash` test to use the new `hashFileWithHasher` method, creating and passing a reusable hasher and buffer. [[1]](diffhunk://#diff-8b731275d2936d9c95d197886fa59d7b8cd161ae1fa4f0156ede14ca55ee6fd5L52-R61) [[2]](diffhunk://#diff-8b731275d2936d9c95d197886fa59d7b8cd161ae1fa4f0156ede14ca55ee6fd5R4)