### PR TITLE
specify workers number

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -97,6 +97,7 @@ func (c *CLI) runGenerate(args []string) int {
 		basePath string
 		appName  string
 		format   string
+		workers  int
 		help     bool
 	)
 
@@ -110,6 +111,7 @@ func (c *CLI) runGenerate(args []string) int {
 	flags.StringVar(&basePath, "base-path", "development", "Base path for S3 (e.g., production, staging, development)")
 	flags.StringVar(&appName, "app-name", "", "Application name for S3 versioning")
 	flags.StringVar(&format, "format", "text", "Output format (text|json)")
+	flags.IntVar(&workers, "workers", 0, "Number of worker threads (0 = auto detect)")
 	flags.BoolVar(&help, "help", false, "Show help for generate command")
 	flags.BoolVar(&help, "h", false, "Show help for generate command")
 
@@ -126,7 +128,7 @@ func (c *CLI) runGenerate(args []string) int {
 	}
 
 	// Generate manifest
-	generator := manifest.NewGenerator()
+	generator := manifest.NewGenerator(workers)
 	m, err := generator.Generate(target, excludes)
 	if err != nil {
 		c.outputGenerateError(err, format)
@@ -193,6 +195,7 @@ func (c *CLI) runVerify(args []string) int {
 		appName      string
 		target       string
 		format       string
+		workers      int
 		help         bool
 	)
 
@@ -206,6 +209,7 @@ func (c *CLI) runVerify(args []string) int {
 	flags.StringVar(&appName, "app-name", "", "Application name for S3")
 	flags.StringVar(&target, "target", ".", "Target directory to verify")
 	flags.StringVar(&format, "format", "text", "Output format (text|json)")
+	flags.IntVar(&workers, "workers", 0, "Number of worker threads (0 = auto detect)")
 	flags.BoolVar(&help, "help", false, "Show help for verify command")
 	flags.BoolVar(&help, "h", false, "Show help for verify command")
 
@@ -255,7 +259,7 @@ func (c *CLI) runVerify(args []string) int {
 	}
 
 	// Verify integrity
-	err = m.Verify(target)
+	err = m.Verify(target, workers)
 
 	// Output result
 	c.outputVerifyResult(err, m, format)

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -36,11 +36,15 @@ type Calculator struct {
 	bufferSize int
 }
 
-// NewCalculator creates a new hash calculator
-func NewCalculator() *Calculator {
+// NewCalculator creates a calculator with custom worker count
+func NewCalculator(numWorkers int) *Calculator {
+	if numWorkers <= 0 {
+		numWorkers = runtime.GOMAXPROCS(0)
+	}
+
 	return &Calculator{
-		numWorkers: runtime.GOMAXPROCS(0), // Use all available CPUs
-		bufferSize: 1024 * 1024,           // 1MB buffer
+		numWorkers: numWorkers,
+		bufferSize: 1024 * 1024, // 1MB buffer
 	}
 }
 
@@ -293,7 +297,7 @@ func matchGlob(pattern, path string) bool {
 
 // VerifyIntegrity verifies the integrity of files against a manifest
 func VerifyIntegrity(manifest *Result, targetDir string) error {
-	calculator := NewCalculator()
+	calculator := NewCalculator(0)
 
 	// Resolve symlink if the target directory itself is a symlink
 	resolvedDir, err := filepath.EvalSymlinks(targetDir)
@@ -352,7 +356,7 @@ func VerifyIntegrity(manifest *Result, targetDir string) error {
 
 // VerifyIntegrityWithPatterns verifies the integrity of files against a manifest with patterns
 func VerifyIntegrityWithPatterns(manifest *Result, targetDir string, excludes []string) error {
-	calculator := NewCalculator()
+	calculator := NewCalculator(0)
 
 	// Resolve symlink if the target directory itself is a symlink
 	resolvedDir, err := filepath.EvalSymlinks(targetDir)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -18,7 +18,7 @@ func TestGenerateManifest(t *testing.T) {
 	tempDir := createTestDirectory(t)
 	defer os.RemoveAll(tempDir)
 
-	generator := NewGenerator()
+	generator := NewGenerator(0)
 	manifest, err := generator.Generate(tempDir, nil)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
@@ -167,14 +167,14 @@ func TestManifestVerify(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Generate manifest
-	generator := NewGenerator()
+	generator := NewGenerator(0)
 	manifest, err := generator.Generate(tempDir, nil)
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
 
 	// Verify should pass
-	err = manifest.Verify(tempDir)
+	err = manifest.Verify(tempDir, 0)
 	if err != nil {
 		t.Errorf("Verify() should pass for unchanged files: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestManifestVerify(t *testing.T) {
 	}
 
 	// Verify should fail
-	err = manifest.Verify(tempDir)
+	err = manifest.Verify(tempDir, 0)
 	if err == nil {
 		t.Error("Verify() should fail for modified files")
 	}
@@ -267,7 +267,7 @@ func TestManifestWithPatterns(t *testing.T) {
 		},
 	}
 
-	generator := NewGenerator()
+	generator := NewGenerator(0)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -305,7 +305,7 @@ func TestManifestExcludePatterns(t *testing.T) {
 	}
 
 	// Generate manifest with excludes
-	generator := NewGenerator()
+	generator := NewGenerator(0)
 	excludes := []string{"*.log", ".env"}
 	manifest, err := generator.Generate(tempDir, excludes)
 	if err != nil {
@@ -326,7 +326,7 @@ func TestManifestExcludePatterns(t *testing.T) {
 
 	// Test manifest.Verify() uses excludes correctly
 	t.Run("verify with original files", func(t *testing.T) {
-		err := manifest.Verify(tempDir)
+		err := manifest.Verify(tempDir, 0)
 		if err != nil {
 			t.Errorf("Verify() should succeed with original files: %v", err)
 		}
@@ -340,7 +340,7 @@ func TestManifestExcludePatterns(t *testing.T) {
 		}
 
 		// Verify should still pass because the file is excluded
-		err := manifest.Verify(tempDir)
+		err := manifest.Verify(tempDir, 0)
 		if err != nil {
 			t.Errorf("Verify() should succeed even with modified excluded file: %v", err)
 		}
@@ -354,7 +354,7 @@ func TestManifestExcludePatterns(t *testing.T) {
 		}
 
 		// Verify should still pass because the file matches exclude pattern
-		err := manifest.Verify(tempDir)
+		err := manifest.Verify(tempDir, 0)
 		if err != nil {
 			t.Errorf("Verify() should succeed even with added excluded file: %v", err)
 		}
@@ -368,7 +368,7 @@ func TestManifestExcludePatterns(t *testing.T) {
 		}
 
 		// Verify should fail because the file is included
-		err := manifest.Verify(tempDir)
+		err := manifest.Verify(tempDir, 0)
 		if err == nil {
 			t.Error("Verify() should fail with modified included file")
 		} else if !strings.Contains(err.Error(), "modified: app.go") {
@@ -389,7 +389,7 @@ func TestManifestExcludePatterns(t *testing.T) {
 		}
 
 		// Verify should fail because the file is not excluded
-		err := manifest.Verify(tempDir)
+		err := manifest.Verify(tempDir, 0)
 		if err == nil {
 			t.Error("Verify() should fail with added included file")
 		} else if !strings.Contains(err.Error(), "added: new.go") {


### PR DESCRIPTION
This pull request adds support for configuring the number of worker threads used during manifest generation and verification, improving performance control and flexibility. It introduces a new `workers` CLI flag for the `generate` and `verify` commands, updates the internal API to propagate this parameter, and enhances the manifest verification logic for more detailed integrity checks. Tests have been updated to cover the new functionality.

**CLI enhancements:**

* Added a `--workers` flag to both the `generate` and `verify` commands in the CLI, allowing users to specify the number of worker threads (0 = auto-detect based on available CPUs). (`internal/cli/cli.go`) [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR100) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR114) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR198) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR212)

**Concurrency and performance improvements:**

* Modified `manifest.NewGenerator` and `hash.NewCalculator` to accept a `numWorkers` parameter, enabling custom worker counts for parallel processing. (`internal/manifest/manifest.go`, `internal/hash/hash.go`) [[1]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L28-R32) [[2]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L28-R32) [[3]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L39-R46)
* Updated all usages of `NewCalculator` and `NewGenerator` in the codebase and tests to pass the appropriate worker count, ensuring consistent worker configuration. (`internal/manifest/manifest.go`, `internal/hash/hash.go`, `internal/manifest/manifest_test.go`, `internal/hash/hash_test.go`) [[1]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L28-R32) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L39-R46) [[3]](diffhunk://#diff-9fa6b9b6ac53923eed836a50409016adb3eff24f78aee49c601106b960ff57acL21-R21) [[4]](diffhunk://#diff-8b731275d2936d9c95d197886fa59d7b8cd161ae1fa4f0156ede14ca55ee6fd5L52-R87) etc.)

**Manifest verification logic:**

* Refactored the `Manifest.Verify` method to accept a worker count and perform a detailed integrity check, reporting added, modified, and deleted files with clear error messages. (`internal/manifest/manifest.go`)

**Testing improvements:**

* Added a unit test for `NewCalculator` to verify correct worker count handling for positive, zero, and negative values. (`internal/hash/hash_test.go`)
* Updated all relevant tests to use the new worker count parameter, ensuring test coverage for the new concurrency logic. (`internal/manifest/manifest_test.go`, `internal/hash/hash_test.go`) [[1]](diffhunk://#diff-9fa6b9b6ac53923eed836a50409016adb3eff24f78aee49c601106b960ff57acL21-R21) [[2]](diffhunk://#diff-8b731275d2936d9c95d197886fa59d7b8cd161ae1fa4f0156ede14ca55ee6fd5L52-R87) etc.)