### PR TITLE
Increase verbosity by adding --workers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Options:
   -base-path string   S3 base path (default "development")
   -app-name string    Application name (creates path: {base-path}/{app-name}/manifest.json)
   -format string      Output format: text, json (default "text")
+  -workers int        Number of worker threads (0 = auto detect)
 ```
 
 ### verify
@@ -320,6 +321,7 @@ Options:
   -app-name string    Application name (reads from: {base-path}/{app-name}/manifest.json)
   -target string      Target directory to verify (default ".")
   -format string      Output format: text, json (default "text")
+  -workers int        Number of worker threads (0 = auto detect)
 ```
 
 ## Output Formats
@@ -357,4 +359,4 @@ A: Verify that the EC2 instance has the correct IAM role configured. Also check 
 
 ### Q: Verification takes too long
 
-A: For large file sets, use `--exclude` options to skip server-generated directories like logs, cache, and temporary files. Note that application dependencies (vendor, node_modules) should still be verified as they are part of the deployed application.
+A: For large file sets, use `--exclude` options to skip server-generated directories like logs, cache, and temporary files. You can also adjust the number of worker threads with `--workers` to optimize performance for your system. Note that application dependencies (vendor, node_modules) should still be verified as they are part of the deployed application.


### PR DESCRIPTION
This pull request updates the `README.md` documentation to clarify and improve usage instructions for the `--workers` option and performance tuning. The main changes are grouped below:

Documentation updates for new option:

* Added the `-workers int` option to the command-line options sections for both main and verify commands, explaining that it controls the number of worker threads and that `0` enables auto-detection. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R308) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R324)

Performance tuning guidance:

* Updated the FAQ to mention the `--workers` option as a way to optimize verification performance for large file sets, in addition to using `--exclude`.