### PR TITLE
Add validation and warning for rate-limit parameter

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -129,6 +129,15 @@ func (c *CLI) runGenerate(args []string) int {
 		return ExitCodeOK
 	}
 
+	// Validate rate limit
+	if rateLimit < 0 {
+		fmt.Fprintf(c.errStream, "Error: rate-limit cannot be negative\n")
+		return ExitCodeFail
+	}
+	if rateLimit > 0 && rateLimit < 1024 {
+		fmt.Fprintf(c.errStream, "Warning: rate-limit %d is very low (< 1KB/s), this may be too restrictive\n", rateLimit)
+	}
+
 	// Generate manifest
 	var generator *manifest.Generator
 	if rateLimit > 0 {
@@ -231,6 +240,15 @@ func (c *CLI) runVerify(args []string) int {
 	if help {
 		c.printVerifyHelp(flags)
 		return ExitCodeOK
+	}
+
+	// Validate rate limit
+	if rateLimit < 0 {
+		fmt.Fprintf(c.errStream, "Error: rate-limit cannot be negative\n")
+		return ExitCodeFail
+	}
+	if rateLimit > 0 && rateLimit < 1024 {
+		fmt.Fprintf(c.errStream, "Warning: rate-limit %d is very low (< 1KB/s), this may be too restrictive\n", rateLimit)
 	}
 
 	// Load manifest


### PR DESCRIPTION
This pull request adds input validation for the `rate-limit` parameter in both the `runGenerate` and `runVerify` CLI commands. The changes ensure that negative values are rejected with an error, and users are warned if they set unusually low rate limits.

**Input validation improvements:**

* Added a check in the `runGenerate` command to prevent negative `rate-limit` values and to warn users if the value is below 1024 bytes per second, helping avoid misconfiguration.
* Added the same validation logic to the `runVerify` command to ensure consistent behavior across both commands.