### PR TITLE
Add timeout option to CLI commands with defaults of 300 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Options:
   -format string      Output format: text, json (default "text")
   -workers int        Number of worker threads (0 = auto detect)
   -rate-limit int     Rate limit in bytes per second (0 = no limit)
+  -timeout int        Timeout in seconds (default: 300)
 ```
 
 ### verify
@@ -324,6 +325,7 @@ Options:
   -format string      Output format: text, json (default "text")
   -workers int        Number of worker threads (0 = auto detect)
   -rate-limit int     Rate limit in bytes per second (0 = no limit)
+  -timeout int        Timeout in seconds (default: 300)
 ```
 
 ## Output Formats

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -103,6 +103,7 @@ func (c *CLI) runGenerate(args []string) int {
 		format    string
 		workers   int
 		rateLimit int64
+		timeout   int
 		help      bool
 	)
 
@@ -118,6 +119,7 @@ func (c *CLI) runGenerate(args []string) int {
 	flags.StringVar(&format, "format", "text", "Output format (text|json)")
 	flags.IntVar(&workers, "workers", 0, "Number of worker threads (0 = auto detect)")
 	flags.Int64Var(&rateLimit, "rate-limit", 0, "Rate limit in bytes per second (0 = no limit)")
+	flags.IntVar(&timeout, "timeout", 300, "Timeout in seconds (default: 300)")
 	flags.BoolVar(&help, "help", false, "Show help for generate command")
 	flags.BoolVar(&help, "h", false, "Show help for generate command")
 
@@ -145,6 +147,13 @@ func (c *CLI) runGenerate(args []string) int {
 	// Create context with signal handling
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Apply timeout if specified
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
 
 	// Generate manifest
 	var generator *manifest.Generator
@@ -222,6 +231,7 @@ func (c *CLI) runVerify(args []string) int {
 		format       string
 		workers      int
 		rateLimit    int64
+		timeout      int
 		help         bool
 	)
 
@@ -237,6 +247,7 @@ func (c *CLI) runVerify(args []string) int {
 	flags.StringVar(&format, "format", "text", "Output format (text|json)")
 	flags.IntVar(&workers, "workers", 0, "Number of worker threads (0 = auto detect)")
 	flags.Int64Var(&rateLimit, "rate-limit", 0, "Rate limit in bytes per second (0 = no limit)")
+	flags.IntVar(&timeout, "timeout", 300, "Timeout in seconds (default: 300)")
 	flags.BoolVar(&help, "help", false, "Show help for verify command")
 	flags.BoolVar(&help, "h", false, "Show help for verify command")
 
@@ -297,6 +308,13 @@ func (c *CLI) runVerify(args []string) int {
 	// Create context with signal handling
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Apply timeout if specified
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
 
 	// Verify integrity
 	if rateLimit > 0 {


### PR DESCRIPTION
This pull request adds a configurable timeout option to both the `generate` and `verify` commands in the CLI, allowing users to specify a maximum duration (in seconds) for each operation. The timeout defaults to 300 seconds and can be customized via a new `-timeout` flag. The change is documented in the `README.md` and implemented in the CLI logic to ensure that long-running operations are automatically cancelled if they exceed the specified timeout.

**CLI Enhancements:**

* Added a new `-timeout` flag (default: 300 seconds) to both the `generate` and `verify` commands, allowing users to specify a timeout for these operations. (`internal/cli/cli.go`, [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR106) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR234)
* Integrated the timeout into the command execution context using `context.WithTimeout`, so operations are cancelled if they exceed the specified duration. (`internal/cli/cli.go`, [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR151-R157) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR312-R318)

**Documentation Updates:**

* Updated the `README.md` to document the new `-timeout` option for both `generate` and `verify` commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R310) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R328)