### PR TITLE
fix: add comprehensive symlink handling tests, manifest verification

### DIFF
--- a/internal/hash/symlink_test.go
+++ b/internal/hash/symlink_test.go
@@ -1,0 +1,694 @@
+package hash
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSymlinkHandlingDetailed(t *testing.T) {
+	// Create test directory
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Test 1: Symlink hash is based on target path
+	t.Run("symlink_hash_based_on_target", func(t *testing.T) {
+		target1 := filepath.Join(tempDir, "target1.txt")
+		target2 := filepath.Join(tempDir, "target2.txt")
+		link := filepath.Join(tempDir, "link")
+
+		// Create targets
+		if err := os.WriteFile(target1, []byte("content1"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target2, []byte("content2"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create symlink to target1
+		if err := os.Symlink("target1.txt", link); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result1, err := calc.CalculateDirectory(ctx, tempDir, []string{"target*.txt"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var hash1 string
+		for _, f := range result1.Files {
+			if f.Path == "link" {
+				hash1 = f.Hash
+				if !f.IsSymlink {
+					t.Error("link should be marked as symlink")
+				}
+				break
+			}
+		}
+
+		// Change symlink to target2
+		if err := os.Remove(link); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("target2.txt", link); err != nil {
+			t.Fatal(err)
+		}
+
+		result2, err := calc.CalculateDirectory(ctx, tempDir, []string{"target*.txt"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var hash2 string
+		for _, f := range result2.Files {
+			if f.Path == "link" {
+				hash2 = f.Hash
+				break
+			}
+		}
+
+		// Hashes should be different
+		if hash1 == hash2 {
+			t.Error("Symlink hash should change when target changes")
+		}
+
+		// Verify hash format
+		hasher := sha256.New()
+		hasher.Write([]byte("symlink:target1.txt"))
+		expectedHash1 := hex.EncodeToString(hasher.Sum(nil))
+		if hash1 != expectedHash1 {
+			t.Errorf("Symlink hash = %s, want %s", hash1, expectedHash1)
+		}
+	})
+
+	// Test 2: Regular file with symlink-like content
+	t.Run("regular_file_with_symlink_content", func(t *testing.T) {
+		file := filepath.Join(tempDir, "fake_symlink.txt")
+		content := "symlink:target.txt"
+
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, f := range result.Files {
+			if f.Path == "fake_symlink.txt" {
+				if f.IsSymlink {
+					t.Error("Regular file should not be marked as symlink")
+				}
+				if f.LinkTarget != "" {
+					t.Error("Regular file should not have LinkTarget")
+				}
+
+				// Calculate expected hash for the content
+				hasher := sha256.New()
+				hasher.Write([]byte(content))
+				expectedHash := hex.EncodeToString(hasher.Sum(nil))
+
+				if f.Hash != expectedHash {
+					t.Errorf("File hash = %s, want %s", f.Hash, expectedHash)
+				}
+				break
+			}
+		}
+	})
+
+	// Test 3: FileInfo structure correctness
+	t.Run("file_info_structure", func(t *testing.T) {
+		// Create regular file
+		regularFile := filepath.Join(tempDir, "regular.txt")
+		regularContent := "regular content"
+		if err := os.WriteFile(regularFile, []byte(regularContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create symlink
+		symlinkFile := filepath.Join(tempDir, "symlink")
+		if err := os.Symlink("regular.txt", symlinkFile); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var regularInfo, symlinkInfo *FileInfo
+		for _, f := range result.Files {
+			switch f.Path {
+			case "regular.txt":
+				regularInfo = &f
+			case "symlink":
+				symlinkInfo = &f
+			}
+		}
+
+		// Check regular file
+		if regularInfo == nil {
+			t.Fatal("Regular file not found")
+		}
+		if regularInfo.IsSymlink {
+			t.Error("Regular file marked as symlink")
+		}
+		if regularInfo.LinkTarget != "" {
+			t.Error("Regular file has LinkTarget")
+		}
+		if regularInfo.Size != int64(len(regularContent)) {
+			t.Errorf("Regular file size = %d, want %d", regularInfo.Size, len(regularContent))
+		}
+
+		// Check symlink
+		if symlinkInfo == nil {
+			t.Fatal("Symlink not found")
+		}
+		if !symlinkInfo.IsSymlink {
+			t.Error("Symlink not marked as symlink")
+		}
+		if symlinkInfo.LinkTarget != "regular.txt" {
+			t.Errorf("Symlink target = %s, want regular.txt", symlinkInfo.LinkTarget)
+		}
+	})
+
+	// Test 4: Broken symlink handling
+	t.Run("broken_symlink", func(t *testing.T) {
+		brokenLink := filepath.Join(tempDir, "broken_link")
+		if err := os.Symlink("non_existent.txt", brokenLink); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		found := false
+		for _, f := range result.Files {
+			if f.Path == "broken_link" {
+				found = true
+				if !f.IsSymlink {
+					t.Error("Broken symlink should be marked as symlink")
+				}
+				if f.LinkTarget != "non_existent.txt" {
+					t.Errorf("Broken symlink target = %s, want non_existent.txt", f.LinkTarget)
+				}
+				// Hash should still be calculated based on target
+				hasher := sha256.New()
+				hasher.Write([]byte("symlink:non_existent.txt"))
+				expectedHash := hex.EncodeToString(hasher.Sum(nil))
+				if f.Hash != expectedHash {
+					t.Errorf("Broken symlink hash = %s, want %s", f.Hash, expectedHash)
+				}
+				break
+			}
+		}
+
+		if !found {
+			t.Error("Broken symlink not included in results")
+		}
+	})
+
+	// Test 5: Symlink to symlink (chain)
+	t.Run("symlink_chain", func(t *testing.T) {
+		// Create a file
+		finalTarget := filepath.Join(tempDir, "final.txt")
+		if err := os.WriteFile(finalTarget, []byte("final content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create first symlink
+		link1 := filepath.Join(tempDir, "link_to_final")
+		if err := os.Symlink("final.txt", link1); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create second symlink pointing to first
+		link2 := filepath.Join(tempDir, "link_to_link")
+		if err := os.Symlink("link_to_final", link2); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Both symlinks should have different hashes
+		var hash1, hash2 string
+		for _, f := range result.Files {
+			if f.Path == "link_to_final" {
+				hash1 = f.Hash
+				if f.LinkTarget != "final.txt" {
+					t.Errorf("link_to_final target = %s, want final.txt", f.LinkTarget)
+				}
+			}
+			if f.Path == "link_to_link" {
+				hash2 = f.Hash
+				if f.LinkTarget != "link_to_final" {
+					t.Errorf("link_to_link target = %s, want link_to_final", f.LinkTarget)
+				}
+			}
+		}
+
+		if hash1 == hash2 {
+			t.Error("Different symlinks should have different hashes")
+		}
+	})
+
+	// Test 6: Directory symlink
+	t.Run("directory_symlink", func(t *testing.T) {
+		// Create a directory
+		subDir := filepath.Join(tempDir, "subdir")
+		if err := os.Mkdir(subDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create file in directory
+		subFile := filepath.Join(subDir, "file.txt")
+		if err := os.WriteFile(subFile, []byte("subfile content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create symlink to directory
+		dirLink := filepath.Join(tempDir, "dir_link")
+		if err := os.Symlink("subdir", dirLink); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The symlink itself should be included
+		found := false
+		for _, f := range result.Files {
+			if f.Path == "dir_link" {
+				found = true
+				if !f.IsSymlink {
+					t.Error("Directory symlink should be marked as symlink")
+				}
+				if f.LinkTarget != "subdir" {
+					t.Errorf("Directory symlink target = %s, want subdir", f.LinkTarget)
+				}
+				break
+			}
+		}
+
+		if !found {
+			// Directory symlinks might be skipped by filepath.Walk
+			t.Log("Directory symlink not included (expected behavior for directory symlinks)")
+		}
+	})
+}
+
+func TestSymlinkAttackPrevention(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Test: Attempt to create collision between symlink and regular file
+	t.Run("hash_collision_prevention", func(t *testing.T) {
+		// Create a symlink
+		target := "target.txt"
+		symlink := filepath.Join(tempDir, "symlink")
+		if err := os.Symlink(target, symlink); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a regular file with content that matches symlink pattern
+		spoofFile := filepath.Join(tempDir, "spoof.txt")
+		spoofContent := "symlink:" + target
+		if err := os.WriteFile(spoofFile, []byte(spoofContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var symlinkInfo, spoofInfo *FileInfo
+		for _, f := range result.Files {
+			switch f.Path {
+			case "symlink":
+				symlinkInfo = &f
+			case "spoof.txt":
+				spoofInfo = &f
+			}
+		}
+
+		if symlinkInfo == nil || spoofInfo == nil {
+			t.Fatal("Files not found in result")
+		}
+
+		// Even if hashes might be similar, type should be different
+		if symlinkInfo.IsSymlink == spoofInfo.IsSymlink {
+			t.Error("Symlink and regular file should have different IsSymlink values")
+		}
+
+		// Sizes should be different
+		if symlinkInfo.Size == spoofInfo.Size {
+			t.Log("Warning: Symlink and spoof file have same size (may vary by OS)")
+		}
+
+		// LinkTarget should only be set for symlink
+		if symlinkInfo.LinkTarget == "" {
+			t.Error("Symlink should have LinkTarget")
+		}
+		if spoofInfo.LinkTarget != "" {
+			t.Error("Regular file should not have LinkTarget")
+		}
+	})
+
+	// Test: Verify detection of file type changes
+	t.Run("type_change_detection", func(t *testing.T) {
+		file := filepath.Join(tempDir, "changeable")
+
+		// Start as regular file
+		if err := os.WriteFile(file, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		calc := NewCalculator(1)
+		result1, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var info1 *FileInfo
+		for _, f := range result1.Files {
+			if f.Path == "changeable" {
+				info1 = &f
+				break
+			}
+		}
+
+		if info1.IsSymlink {
+			t.Error("Regular file marked as symlink")
+		}
+
+		// Change to symlink
+		if err := os.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("target", file); err != nil {
+			t.Fatal(err)
+		}
+
+		result2, err := calc.CalculateDirectory(ctx, tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var info2 *FileInfo
+		for _, f := range result2.Files {
+			if f.Path == "changeable" {
+				info2 = &f
+				break
+			}
+		}
+
+		if !info2.IsSymlink {
+			t.Error("Symlink not marked as symlink")
+		}
+
+		// Type should be different
+		if info1.IsSymlink == info2.IsSymlink {
+			t.Error("Type change not detected")
+		}
+	})
+}
+
+func TestFileInfoJSON(t *testing.T) {
+	// Test JSON marshaling of FileInfo
+	fi := FileInfo{
+		Path:       "test.txt",
+		Hash:       "abc123",
+		Size:       100,
+		ModTime:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		IsSymlink:  true,
+		LinkTarget: "target.txt",
+	}
+
+	// This test ensures that FileInfo can be properly serialized
+	// which is important for manifest generation
+	t.Run("json_fields", func(t *testing.T) {
+		if fi.Path != "test.txt" {
+			t.Error("Path field incorrect")
+		}
+		if fi.Hash != "abc123" {
+			t.Error("Hash field incorrect")
+		}
+		if fi.Size != 100 {
+			t.Error("Size field incorrect")
+		}
+		if !fi.IsSymlink {
+			t.Error("IsSymlink field incorrect")
+		}
+		if fi.LinkTarget != "target.txt" {
+			t.Error("LinkTarget field incorrect")
+		}
+	})
+}
+
+func TestSymlinkExcludePatterns(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Create test structure
+	regularFile := filepath.Join(tempDir, "regular.txt")
+	symlink1 := filepath.Join(tempDir, "link1.lnk")
+	symlink2 := filepath.Join(tempDir, "link2.sym")
+
+	if err := os.WriteFile(regularFile, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("regular.txt", symlink1); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("regular.txt", symlink2); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		excludes []string
+		expected []string
+	}{
+		{
+			name:     "no excludes",
+			excludes: nil,
+			expected: []string{"regular.txt", "link1.lnk", "link2.sym"},
+		},
+		{
+			name:     "exclude .lnk files",
+			excludes: []string{"*.lnk"},
+			expected: []string{"regular.txt", "link2.sym"},
+		},
+		{
+			name:     "exclude all symlinks by pattern",
+			excludes: []string{"*.lnk", "*.sym"},
+			expected: []string{"regular.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calc := NewCalculator(1)
+			result, err := calc.CalculateDirectory(ctx, tempDir, tt.excludes)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(result.Files) != len(tt.expected) {
+				t.Errorf("Expected %d files, got %d", len(tt.expected), len(result.Files))
+			}
+
+			for _, expectedFile := range tt.expected {
+				found := false
+				for _, f := range result.Files {
+					if f.Path == expectedFile {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected file %s not found", expectedFile)
+				}
+			}
+		})
+	}
+}
+
+func TestCalculateTotalHashWithSymlinks(t *testing.T) {
+	calc := NewCalculator(1)
+
+	files := []FileInfo{
+		{
+			Path:      "file1.txt",
+			Hash:      "hash1",
+			Size:      100,
+			IsSymlink: false,
+		},
+		{
+			Path:       "link1",
+			Hash:       "hash2",
+			Size:       0,
+			IsSymlink:  true,
+			LinkTarget: "file1.txt",
+		},
+		{
+			Path:      "file2.txt",
+			Hash:      "hash3",
+			Size:      200,
+			IsSymlink: false,
+		},
+	}
+
+	totalHash := calc.calculateTotalHash(files)
+	if totalHash == "" {
+		t.Error("Total hash should not be empty")
+	}
+
+	// Ensure deterministic hash
+	totalHash2 := calc.calculateTotalHash(files)
+	if totalHash != totalHash2 {
+		t.Error("Total hash should be deterministic")
+	}
+
+	// Change symlink target should change total hash
+	files[1].LinkTarget = "different.txt"
+	files[1].Hash = "hash2_modified"
+	totalHash3 := calc.calculateTotalHash(files)
+	if totalHash == totalHash3 {
+		t.Error("Total hash should change when symlink target changes")
+	}
+}
+
+func TestParallelSymlinkProcessing(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Create many symlinks to test parallel processing
+	numFiles := 20
+	for i := 0; i < numFiles; i++ {
+		// Create regular files
+		file := filepath.Join(tempDir, fmt.Sprintf("file%d.txt", i))
+		if err := os.WriteFile(file, []byte(fmt.Sprintf("content%d", i)), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create symlinks
+		link := filepath.Join(tempDir, fmt.Sprintf("link%d", i))
+		if err := os.Symlink(fmt.Sprintf("file%d.txt", i), link); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Test with different worker counts
+	for _, workers := range []int{1, 4, 8} {
+		t.Run(fmt.Sprintf("workers_%d", workers), func(t *testing.T) {
+			calc := NewCalculator(workers)
+			result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Should have 2 * numFiles entries (files + symlinks)
+			if len(result.Files) != 2*numFiles {
+				t.Errorf("Expected %d files, got %d", 2*numFiles, len(result.Files))
+			}
+
+			// Count symlinks
+			symlinkCount := 0
+			for _, f := range result.Files {
+				if f.IsSymlink {
+					symlinkCount++
+					if f.LinkTarget == "" {
+						t.Error("Symlink missing LinkTarget")
+					}
+				}
+			}
+
+			if symlinkCount != numFiles {
+				t.Errorf("Expected %d symlinks, got %d", numFiles, symlinkCount)
+			}
+		})
+	}
+}
+
+func TestSymlinkWithSpecialCharacters(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Test symlinks with special characters in target
+	specialTargets := []string{
+		"file with spaces.txt",
+		"file-with-dashes.txt",
+		"file_with_underscores.txt",
+		"file.with.dots.txt",
+		"文件.txt", // Unicode characters
+	}
+
+	for _, target := range specialTargets {
+		t.Run(strings.ReplaceAll(target, " ", "_"), func(t *testing.T) {
+			// Create target file
+			targetPath := filepath.Join(tempDir, target)
+			if err := os.WriteFile(targetPath, []byte("content"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Create symlink
+			linkName := "link_to_" + strings.ReplaceAll(target, " ", "_")
+			linkPath := filepath.Join(tempDir, linkName)
+			if err := os.Symlink(target, linkPath); err != nil {
+				t.Fatal(err)
+			}
+
+			calc := NewCalculator(1)
+			result, err := calc.CalculateDirectory(ctx, tempDir, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Find the symlink
+			found := false
+			for _, f := range result.Files {
+				if f.Path == linkName {
+					found = true
+					if !f.IsSymlink {
+						t.Error("Should be marked as symlink")
+					}
+					if f.LinkTarget != target {
+						t.Errorf("LinkTarget = %s, want %s", f.LinkTarget, target)
+					}
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("Symlink %s not found", linkName)
+			}
+
+			// Clean up for next test
+			os.Remove(linkPath)
+			os.Remove(targetPath)
+		})
+	}
+}

--- a/internal/manifest/integration_test.go
+++ b/internal/manifest/integration_test.go
@@ -1,0 +1,480 @@
+package manifest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIntegrationSymlinkAttackScenarios(t *testing.T) {
+	// Complete integration tests for various attack scenarios
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Scenario 1: Initial legitimate setup
+	t.Run("complete_attack_scenario", func(t *testing.T) {
+		// Step 1: Create legitimate files and symlinks
+		legitimateFile := filepath.Join(tempDir, "config.json")
+		sensitiveFile := filepath.Join(tempDir, "sensitive.txt")
+		publicLink := filepath.Join(tempDir, "public_config")
+
+		// Create legitimate configuration
+		if err := os.WriteFile(legitimateFile, []byte(`{"public": "data"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create sensitive file
+		if err := os.WriteFile(sensitiveFile, []byte("SECRET_KEY=abc123"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create legitimate symlink to public config
+		if err := os.Symlink("config.json", publicLink); err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate initial manifest
+		generator := NewGenerator(2)
+		manifest, err := generator.Generate(ctx, tempDir, []string{"sensitive.txt"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Initial verification should pass
+		if err := manifest.Verify(ctx, tempDir, 2); err != nil {
+			t.Errorf("Initial verification failed: %v", err)
+		}
+
+		// Step 2: Attacker tries to replace symlink with file containing "symlink:" prefix
+		if err := os.Remove(publicLink); err != nil {
+			t.Fatal(err)
+		}
+
+		// Attacker creates a file with symlink-like content trying to maintain same hash
+		attackContent := "symlink:config.json"
+		if err := os.WriteFile(publicLink, []byte(attackContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verification should detect type change
+		err = manifest.Verify(ctx, tempDir, 2)
+		if err == nil {
+			t.Error("Should detect symlink replaced with regular file")
+		} else if !strings.Contains(err.Error(), "type changed") {
+			t.Errorf("Expected type change error, got: %v", err)
+		}
+
+		// Step 3: Attacker tries to change symlink target to sensitive file
+		if err := os.Remove(publicLink); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("sensitive.txt", publicLink); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verification should detect hash change (different target)
+		err = manifest.Verify(ctx, tempDir, 2)
+		if err == nil {
+			t.Error("Should detect symlink target change")
+		} else if !strings.Contains(err.Error(), "modified") {
+			t.Errorf("Expected modification error, got: %v", err)
+		}
+	})
+
+	// Scenario 2: Race condition attack attempt
+	t.Run("race_condition_attack", func(t *testing.T) {
+		raceDir := filepath.Join(tempDir, "race")
+		if err := os.Mkdir(raceDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		normalFile := filepath.Join(raceDir, "normal.txt")
+		if err := os.WriteFile(normalFile, []byte("normal content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		generator := NewGenerator(2)
+		manifest, err := generator.Generate(ctx, raceDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate attack: quickly switch between file and symlink
+		for i := 0; i < 5; i++ {
+			// Replace with symlink
+			if err := os.Remove(normalFile); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("/etc/passwd", normalFile); err != nil {
+				t.Fatal(err)
+			}
+
+			// Verification should catch the type change
+			err := manifest.Verify(ctx, raceDir, 2)
+			if err == nil {
+				t.Error("Should detect file type change in race condition")
+			}
+
+			// Restore original
+			if err := os.Remove(normalFile); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(normalFile, []byte("normal content"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Should pass with original
+			err = manifest.Verify(ctx, raceDir, 2)
+			if err != nil {
+				t.Errorf("Should pass with original file: %v", err)
+			}
+		}
+	})
+
+	// Scenario 3: Complex symlink chain manipulation
+	t.Run("symlink_chain_manipulation", func(t *testing.T) {
+		chainDir := filepath.Join(tempDir, "chain")
+		if err := os.Mkdir(chainDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create chain: link3 -> link2 -> link1 -> target
+		target := filepath.Join(chainDir, "target.txt")
+		link1 := filepath.Join(chainDir, "link1")
+		link2 := filepath.Join(chainDir, "link2")
+		link3 := filepath.Join(chainDir, "link3")
+
+		if err := os.WriteFile(target, []byte("target content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("target.txt", link1); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("link1", link2); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("link2", link3); err != nil {
+			t.Fatal(err)
+		}
+
+		generator := NewGenerator(2)
+		manifest, err := generator.Generate(ctx, chainDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Try to manipulate middle of chain
+		if err := os.Remove(link2); err != nil {
+			t.Fatal(err)
+		}
+		// Replace with direct link to different target
+		maliciousTarget := filepath.Join(chainDir, "malicious.txt")
+		if err := os.WriteFile(maliciousTarget, []byte("malicious"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("malicious.txt", link2); err != nil {
+			t.Fatal(err)
+		}
+
+		// Should detect the change
+		err = manifest.Verify(ctx, chainDir, 2)
+		if err == nil {
+			t.Error("Should detect symlink chain manipulation")
+		}
+	})
+
+	// Scenario 4: Hidden file attack via symlink
+	t.Run("hidden_file_via_symlink", func(t *testing.T) {
+		hiddenDir := filepath.Join(tempDir, "hidden")
+		if err := os.Mkdir(hiddenDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create visible file
+		visibleFile := filepath.Join(hiddenDir, "visible.txt")
+		if err := os.WriteFile(visibleFile, []byte("visible"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create symlink
+		link := filepath.Join(hiddenDir, "link")
+		if err := os.Symlink("visible.txt", link); err != nil {
+			t.Fatal(err)
+		}
+
+		generator := NewGenerator(2)
+		manifest, err := generator.Generate(ctx, hiddenDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create hidden file
+		hiddenFile := filepath.Join(hiddenDir, ".hidden")
+		if err := os.WriteFile(hiddenFile, []byte("hidden content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Try to point symlink to hidden file
+		if err := os.Remove(link); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(".hidden", link); err != nil {
+			t.Fatal(err)
+		}
+
+		// Should detect the change
+		err = manifest.Verify(ctx, hiddenDir, 2)
+		if err == nil {
+			t.Error("Should detect symlink retargeting to hidden file")
+		} else if !strings.Contains(err.Error(), "modified") && !strings.Contains(err.Error(), "added") {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	// Scenario 5: Size-based attack detection
+	t.Run("size_based_attack_detection", func(t *testing.T) {
+		sizeDir := filepath.Join(tempDir, "size")
+		if err := os.Mkdir(sizeDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create files with specific sizes
+		smallFile := filepath.Join(sizeDir, "small.txt")
+		largeFile := filepath.Join(sizeDir, "large.txt")
+
+		if err := os.WriteFile(smallFile, []byte("small"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create large content
+		largeContent := make([]byte, 10000)
+		for i := range largeContent {
+			largeContent[i] = 'A'
+		}
+		if err := os.WriteFile(largeFile, largeContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		generator := NewGenerator(2)
+		manifest, err := generator.Generate(ctx, sizeDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Try to swap files (simulating hash collision but different sizes)
+		// This tests that size verification provides additional security
+		if err := os.WriteFile(smallFile, largeContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(largeFile, []byte("small"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		err = manifest.Verify(ctx, sizeDir, 2)
+		if err == nil {
+			t.Error("Should detect file size changes")
+		}
+		// The error will be about hash mismatch since content changed
+		// But size is also verified as part of FileInfo comparison
+	})
+
+	// Scenario 6: Symlink with same name as excluded file
+	t.Run("symlink_excluded_name_attack", func(t *testing.T) {
+		excludeDir := filepath.Join(tempDir, "exclude")
+		if err := os.Mkdir(excludeDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create files
+		configFile := filepath.Join(excludeDir, "config.txt")
+		logFile := filepath.Join(excludeDir, "app.log")
+
+		if err := os.WriteFile(configFile, []byte("config"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(logFile, []byte("log data"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate manifest excluding .log files
+		generator := NewGenerator(2)
+		manifest, err := generator.Generate(ctx, excludeDir, []string{"*.log"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Remove log file and create symlink with same name
+		if err := os.Remove(logFile); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("/etc/passwd", logFile); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verification should still pass (file is excluded)
+		err = manifest.Verify(ctx, excludeDir, 2)
+		if err != nil {
+			t.Errorf("Excluded files should not affect verification: %v", err)
+		}
+
+		// But if we create a symlink with included name
+		includedLink := filepath.Join(excludeDir, "newlink.txt")
+		if err := os.Symlink("/etc/passwd", includedLink); err != nil {
+			t.Fatal(err)
+		}
+
+		// Should detect the added file
+		err = manifest.Verify(ctx, excludeDir, 2)
+		if err == nil {
+			t.Error("Should detect added symlink")
+		} else if !strings.Contains(err.Error(), "added") {
+			t.Errorf("Expected 'added' error, got: %v", err)
+		}
+	})
+}
+
+func TestManifestGenerationAndVerificationPerformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping performance test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Create many files and symlinks
+	numFiles := 100
+	for i := 0; i < numFiles; i++ {
+		file := filepath.Join(tempDir, fmt.Sprintf("file%d.txt", i))
+		if err := os.WriteFile(file, []byte(fmt.Sprintf("content%d", i)), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if i%2 == 0 {
+			link := filepath.Join(tempDir, fmt.Sprintf("link%d", i))
+			if err := os.Symlink(fmt.Sprintf("file%d.txt", i), link); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Test generation performance
+	start := time.Now()
+	generator := NewGeneratorWithRateLimit(4, 10*1024*1024) // 10MB/s
+	manifest, err := generator.Generate(ctx, tempDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	genDuration := time.Since(start)
+
+	t.Logf("Generation took %v for %d files", genDuration, manifest.FileCount)
+
+	// Test verification performance
+	start = time.Now()
+	err = manifest.VerifyWithRateLimit(ctx, tempDir, 4, 10*1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifyDuration := time.Since(start)
+
+	t.Logf("Verification took %v for %d files", verifyDuration, manifest.FileCount)
+
+	// Test cache-based verification performance
+	cacheDir := t.TempDir()
+	start = time.Now()
+	err = manifest.VerifyWithCache(ctx, tempDir, cacheDir, "test", "app", 4, 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheVerifyDuration := time.Since(start)
+
+	t.Logf("Cache verification took %v for %d files", cacheVerifyDuration, manifest.FileCount)
+
+	// Second cache verification should be faster
+	start = time.Now()
+	err = manifest.VerifyWithCache(ctx, tempDir, cacheDir, "test", "app", 4, 0.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache2Duration := time.Since(start)
+
+	t.Logf("Second cache verification took %v (should be faster)", cache2Duration)
+
+	if cache2Duration >= cacheVerifyDuration {
+		t.Log("Warning: Second cache verification was not faster")
+	}
+}
+
+func TestConcurrentVerification(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Create test files
+	for i := 0; i < 10; i++ {
+		file := filepath.Join(tempDir, fmt.Sprintf("file%d.txt", i))
+		if err := os.WriteFile(file, []byte(fmt.Sprintf("content%d", i)), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	generator := NewGenerator(2)
+	manifest, err := generator.Generate(ctx, tempDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run multiple verifications concurrently
+	done := make(chan error, 5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			done <- manifest.Verify(ctx, tempDir, 2)
+		}()
+	}
+
+	// All should succeed
+	for i := 0; i < 5; i++ {
+		if err := <-done; err != nil {
+			t.Errorf("Concurrent verification %d failed: %v", i, err)
+		}
+	}
+}
+
+func TestManifestBackwardCompatibility(t *testing.T) {
+	// Test that manifests with and without symlink fields work correctly
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	file := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(file, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate current manifest
+	generator := NewGenerator(1)
+	manifest, err := generator.Generate(ctx, tempDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all expected fields are present
+	for _, f := range manifest.Files {
+		if f.Path == "" {
+			t.Error("Path should not be empty")
+		}
+		if f.Hash == "" {
+			t.Error("Hash should not be empty")
+		}
+		// Size can be 0 for empty files
+		// IsSymlink defaults to false
+		// LinkTarget can be empty for non-symlinks
+	}
+
+	// Test verification still works
+	err = manifest.Verify(ctx, tempDir, 1)
+	if err != nil {
+		t.Errorf("Verification failed: %v", err)
+	}
+}

--- a/internal/manifest/symlink_spoof_test.go
+++ b/internal/manifest/symlink_spoof_test.go
@@ -1,0 +1,455 @@
+package manifest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/catatsuy/kekkai/internal/hash"
+)
+
+func TestSymlinkSpoofingPrevention(t *testing.T) {
+	// Create test directory
+	tempDir := t.TempDir()
+
+	// Create original files
+	targetFile := filepath.Join(tempDir, "target.txt")
+	if err := os.WriteFile(targetFile, []byte("original content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(tempDir, "link")
+	if err := os.Symlink("target.txt", linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate manifest
+	generator := NewGenerator(0)
+	manifest, err := generator.Generate(context.Background(), tempDir, nil)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	// Initial verification should pass
+	err = manifest.Verify(context.Background(), tempDir, 0)
+	if err != nil {
+		t.Errorf("Initial verify should pass: %v", err)
+	}
+
+	// Test 1: Replace symlink with regular file containing "symlink:<path>"
+	t.Run("replace_symlink_with_spoofed_file", func(t *testing.T) {
+		// Remove the symlink
+		if err := os.Remove(linkPath); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a regular file with content that matches symlink hash pattern
+		spoofContent := "symlink:target.txt"
+		if err := os.WriteFile(linkPath, []byte(spoofContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verification should fail due to type change
+		err := manifest.Verify(context.Background(), tempDir, 0)
+		if err == nil {
+			t.Error("Verify() should fail when symlink is replaced with regular file")
+		} else if !strings.Contains(err.Error(), "type changed") {
+			t.Errorf("Error should mention type change, got: %v", err)
+		}
+
+		// Restore the symlink
+		if err := os.Remove(linkPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("target.txt", linkPath); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test 2: Replace regular file with symlink
+	t.Run("replace_file_with_symlink", func(t *testing.T) {
+		// Create a regular file first
+		regularFile := filepath.Join(tempDir, "regular.txt")
+		if err := os.WriteFile(regularFile, []byte("regular content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate new manifest with the regular file
+		manifest2, err := generator.Generate(context.Background(), tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Remove regular file and create symlink with same name
+		if err := os.Remove(regularFile); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("target.txt", regularFile); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verification should fail due to type change
+		err = manifest2.Verify(context.Background(), tempDir, 0)
+		if err == nil {
+			t.Error("Verify() should fail when regular file is replaced with symlink")
+		} else if !strings.Contains(err.Error(), "type changed") {
+			t.Errorf("Error should mention type change, got: %v", err)
+		}
+
+		// Clean up
+		if err := os.Remove(regularFile); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test 3: File size verification for regular files
+	t.Run("file_size_change_detection", func(t *testing.T) {
+		// Create a test file with specific content
+		sizeTestFile := filepath.Join(tempDir, "size_test.txt")
+		originalContent := "original"
+		if err := os.WriteFile(sizeTestFile, []byte(originalContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate manifest
+		manifest3, err := generator.Generate(context.Background(), tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Find and modify the file's entry to simulate size mismatch
+		// Note: Hash will not match but we're testing if size check happens
+		found := false
+		for i := range manifest3.Files {
+			if manifest3.Files[i].Path == "size_test.txt" {
+				// Store original values
+				originalHash := manifest3.Files[i].Hash
+				originalSize := manifest3.Files[i].Size
+
+				// Set incorrect size but keep correct hash to test size validation
+				manifest3.Files[i].Size = 1000 // Different from actual size
+
+				// Since hash and size won't match together normally,
+				// we're testing that the error message prioritizes type/size checks
+				found = true
+
+				// Restore for proper test
+				manifest3.Files[i].Hash = originalHash
+				manifest3.Files[i].Size = originalSize
+				break
+			}
+		}
+
+		if !found {
+			t.Fatal("size_test.txt not found in manifest")
+		}
+
+		// Test with actual file size change
+		// Write different content to change the file
+		if err := os.WriteFile(sizeTestFile, []byte("modified content that is longer"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verification should fail
+		err = manifest3.Verify(context.Background(), tempDir, 0)
+		if err == nil {
+			t.Error("Verify() should fail when file content and size change")
+		} else if !strings.Contains(err.Error(), "modified") {
+			// Will report as "modified" since hash changed
+			t.Errorf("Error should mention modification, got: %v", err)
+		}
+
+		// Clean up
+		if err := os.Remove(sizeTestFile); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test 4: Ensure symlink size is not validated (since it's meaningless)
+	t.Run("symlink_size_not_validated", func(t *testing.T) {
+		// Create a new symlink
+		symlinkTestPath := filepath.Join(tempDir, "symlink_test")
+		if err := os.Symlink("target.txt", symlinkTestPath); err != nil {
+			t.Fatal(err)
+		}
+
+		// Generate manifest
+		manifest4, err := generator.Generate(context.Background(), tempDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Manually modify the symlink's size in the manifest
+		// This shouldn't cause verification to fail since symlink sizes are not meaningful
+		for i := range manifest4.Files {
+			if manifest4.Files[i].Path == "symlink_test" && manifest4.Files[i].IsSymlink {
+				manifest4.Files[i].Size = 99999 // Arbitrary different size
+				break
+			}
+		}
+
+		// Verification should still pass (symlink size is ignored)
+		err = manifest4.Verify(context.Background(), tempDir, 0)
+		if err != nil {
+			t.Errorf("Verify() should pass even with different symlink size: %v", err)
+		}
+
+		// Clean up
+		if err := os.Remove(symlinkTestPath); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestManifestVerifyWithTypeAndSize(t *testing.T) {
+	// Create test directory
+	tempDir := t.TempDir()
+
+	// Create test files
+	file1 := filepath.Join(tempDir, "file1.txt")
+	file2 := filepath.Join(tempDir, "file2.txt")
+	link1 := filepath.Join(tempDir, "link1")
+
+	if err := os.WriteFile(file1, []byte("content1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file2, []byte("content2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("file1.txt", link1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate manifest
+	generator := NewGenerator(0)
+	_, err := generator.Generate(context.Background(), tempDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a custom manifest to test verification logic
+	testManifest := &Manifest{
+		Version:     "1.0",
+		TotalHash:   "dummy", // Force detailed comparison
+		FileCount:   3,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Files: []hash.FileInfo{
+			{
+				Path:      "file1.txt",
+				Hash:      "hash1",
+				Size:      8,
+				IsSymlink: false,
+			},
+			{
+				Path:      "file2.txt",
+				Hash:      "hash2",
+				Size:      8,
+				IsSymlink: false,
+			},
+			{
+				Path:       "link1",
+				Hash:       "linkhash",
+				Size:       0,
+				IsSymlink:  true,
+				LinkTarget: "file1.txt",
+			},
+		},
+	}
+
+	// Test scenarios
+	tests := []struct {
+		name        string
+		setup       func()
+		expectError string
+		cleanup     func()
+	}{
+		{
+			name: "type_changed_symlink_to_file",
+			setup: func() {
+				os.Remove(link1)
+				os.WriteFile(link1, []byte("spoofed"), 0644)
+			},
+			expectError: "type changed: link1",
+			cleanup: func() {
+				os.Remove(link1)
+				os.Symlink("file1.txt", link1)
+			},
+		},
+		{
+			name: "type_changed_file_to_symlink",
+			setup: func() {
+				os.Remove(file2)
+				os.Symlink("file1.txt", file2)
+			},
+			expectError: "type changed: file2.txt",
+			cleanup: func() {
+				os.Remove(file2)
+				os.WriteFile(file2, []byte("content2"), 0644)
+			},
+		},
+		{
+			name: "size_changed_regular_file",
+			setup: func() {
+				// Create manifest with correct hash but wrong size
+				for i := range testManifest.Files {
+					if testManifest.Files[i].Path == "file1.txt" {
+						// Get actual hash
+						calc := hash.NewCalculator(1)
+						result, _ := calc.CalculateDirectory(context.Background(), tempDir, nil)
+						for _, f := range result.Files {
+							if f.Path == "file1.txt" {
+								testManifest.Files[i].Hash = f.Hash
+								testManifest.Files[i].Size = 999 // Wrong size
+								break
+							}
+						}
+						break
+					}
+				}
+			},
+			expectError: "size changed: file1.txt",
+			cleanup: func() {
+				// Restore correct size
+				for i := range testManifest.Files {
+					if testManifest.Files[i].Path == "file1.txt" {
+						testManifest.Files[i].Size = 8
+						testManifest.Files[i].Hash = "hash1"
+						break
+					}
+				}
+			},
+		},
+		{
+			name: "hash_mismatch",
+			setup: func() {
+				// Set correct type and size but wrong hash
+				for i := range testManifest.Files {
+					if testManifest.Files[i].Path == "file1.txt" {
+						testManifest.Files[i].Size = 8
+						testManifest.Files[i].IsSymlink = false
+						testManifest.Files[i].Hash = "wronghash"
+						break
+					}
+				}
+			},
+			expectError: "modified: file1.txt",
+			cleanup: func() {
+				for i := range testManifest.Files {
+					if testManifest.Files[i].Path == "file1.txt" {
+						testManifest.Files[i].Hash = "hash1"
+						break
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			defer tt.cleanup()
+
+			err := testManifest.Verify(context.Background(), tempDir, 0)
+			if tt.expectError != "" {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tt.expectError)
+				} else if !strings.Contains(err.Error(), tt.expectError) {
+					t.Errorf("Expected error containing '%s', got: %v", tt.expectError, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSymlinkHashCalculation(t *testing.T) {
+	// Create test directory
+	tempDir := t.TempDir()
+
+	// Create a target file
+	targetFile := filepath.Join(tempDir, "target.txt")
+	if err := os.WriteFile(targetFile, []byte("target content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlinks pointing to different targets
+	link1 := filepath.Join(tempDir, "link1")
+	link2 := filepath.Join(tempDir, "link2")
+
+	if err := os.Symlink("target.txt", link1); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("different_target.txt", link2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate manifest
+	generator := NewGenerator(0)
+	manifest, err := generator.Generate(context.Background(), tempDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the two symlinks in the manifest
+	var hash1, hash2 string
+	for _, file := range manifest.Files {
+		if file.Path == "link1" {
+			hash1 = file.Hash
+			if !file.IsSymlink {
+				t.Error("link1 should be marked as symlink")
+			}
+			if file.LinkTarget != "target.txt" {
+				t.Errorf("link1 target = %s, want target.txt", file.LinkTarget)
+			}
+		}
+		if file.Path == "link2" {
+			hash2 = file.Hash
+			if !file.IsSymlink {
+				t.Error("link2 should be marked as symlink")
+			}
+			if file.LinkTarget != "different_target.txt" {
+				t.Errorf("link2 target = %s, want different_target.txt", file.LinkTarget)
+			}
+		}
+	}
+
+	// Hashes should be different because they point to different targets
+	if hash1 == hash2 {
+		t.Error("Symlinks with different targets should have different hashes")
+	}
+
+	// Test that a regular file with "symlink:" content gets a different hash
+	spoofFile := filepath.Join(tempDir, "spoof.txt")
+	if err := os.WriteFile(spoofFile, []byte("symlink:target.txt"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate new manifest
+	manifest2, err := generator.Generate(context.Background(), tempDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the spoof file
+	var spoofIsSymlink bool
+	for _, file := range manifest2.Files {
+		if file.Path == "spoof.txt" {
+			spoofIsSymlink = file.IsSymlink
+			break
+		}
+	}
+
+	// The spoof file should not be marked as symlink
+	if spoofIsSymlink {
+		t.Error("Regular file should not be marked as symlink")
+	}
+
+	// Even if hash might collide, the type difference will catch it
+	// during verification
+}


### PR DESCRIPTION
This pull request enhances the file verification logic in the `Manifest` by improving how file differences are detected. The changes now allow the system to check not just for hash mismatches, but also for file type changes (such as between regular files and symlinks) and file size differences. This results in more accurate and informative reporting of file modifications.

**Improvements to file verification:**

* Updated the detailed comparison logic in `Manifest.verifyWithCalculator` to track and compare full `hash.FileInfo` objects instead of just file hashes, enabling richer checks.
* Added detection of file type changes (e.g., regular file vs. symlink) and file size changes (for regular files) when verifying files, resulting in more precise reporting of file changes.
* Enhanced issue reporting to distinguish between modified, deleted, type-changed, and size-changed files, improving clarity for users.