### PR TITLE
go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/catatsuy/kekkai
 
 go 1.25.0
 
-require github.com/aws/aws-sdk-go v1.55.8
-
 require (
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
+	github.com/aws/aws-sdk-go v1.55.8
+	golang.org/x/time v0.12.0
 )
+
+require github.com/jmespath/go-jmespath v0.4.0 // indirect


### PR DESCRIPTION
This pull request makes a minor update to the `go.mod` file to clean up the way dependencies are listed. The main change is reorganizing the order and grouping of required modules, but there are no functional or version updates.

- Dependency management:
  * Moved `github.com/aws/aws-sdk-go` and `golang.org/x/time` into the main `require` block and listed `github.com/jmespath/go-jmespath` as a separate indirect dependency for improved clarity in `go.mod`.