### PR TITLE
Update test to modify file content and permissions

### DIFF
--- a/internal/hash/hash_cache_test.go
+++ b/internal/hash/hash_cache_test.go
@@ -142,14 +142,23 @@ func TestCalculator_CacheWithFileModification(t *testing.T) {
 		t.Fatalf("SaveMetadataCache() failed: %v", err)
 	}
 
-	// Modify file
-	modifiedContent := []byte("modified content")
+	// Sleep first to ensure different timestamp
+	time.Sleep(1 * time.Second)
+
+	// Modify file content and permissions to ensure ctime changes
+	modifiedContent := []byte("modified content that is significantly different from original")
 	err = os.WriteFile(testFile, modifiedContent, 0644)
 	if err != nil {
 		t.Fatalf("Failed to modify test file: %v", err)
 	}
 
-	// Sleep to ensure timestamp changes
+	// Change permissions to ensure ctime change on Linux
+	err = os.Chmod(testFile, 0755)
+	if err != nil {
+		t.Fatalf("Failed to change file permissions: %v", err)
+	}
+
+	// Additional sleep to ensure timestamp changes are visible
 	time.Sleep(100 * time.Millisecond)
 
 	// Create new calculator


### PR DESCRIPTION
This pull request improves the reliability of the `TestCalculator_CacheWithFileModification` test in `internal/hash/hash_cache_test.go` by ensuring that file modification times and metadata changes are more likely to be detected during the test. The changes are focused on making the test more robust across different operating systems.

Test robustness improvements:

* Added a sleep before modifying the file to ensure a different timestamp is recorded.
* Modified the file content to be significantly different from the original, increasing the likelihood of detecting changes.
* Changed the file permissions after modifying the content to ensure the file's ctime changes, which is especially important on Linux systems.
* Added an additional sleep after changing permissions to ensure that timestamp changes are visible and detectable by the test.