### PR TITLE
Remove total_hash fields and corresponding tests for consistency

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -360,7 +360,6 @@ func (c *CLI) outputGenerateSuccess(m *manifest.Manifest, outputPath, s3Key, for
 	result := &output.GenerationResult{
 		Success:    true,
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
-		TotalHash:  m.TotalHash,
 		FileCount:  m.FileCount,
 		OutputPath: outputPath,
 		S3Key:      s3Key,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -154,8 +154,8 @@ func TestCLIGenerate(t *testing.T) {
 				if !strings.Contains(stdout, `"version"`) {
 					t.Error("Output should contain version field")
 				}
-				if !strings.Contains(stdout, `"total_hash"`) {
-					t.Error("Output should contain total_hash field")
+				if !strings.Contains(stdout, `"file_count"`) {
+					t.Error("Output should contain file_count field")
 				}
 				if !strings.Contains(stdout, `"files"`) {
 					t.Error("Output should contain files field")

--- a/internal/hash/hash_cache_test.go
+++ b/internal/hash/hash_cache_test.go
@@ -91,9 +91,6 @@ func TestCalculator_WithMetadataCache(t *testing.T) {
 	}
 
 	// Results should be identical
-	if result1.TotalHash != result2.TotalHash {
-		t.Errorf("Total hash mismatch: %s != %s", result1.TotalHash, result2.TotalHash)
-	}
 
 	if result1.FileCount != result2.FileCount {
 		t.Errorf("File count mismatch: %d != %d", result1.FileCount, result2.FileCount)
@@ -189,9 +186,9 @@ func TestCalculator_CacheWithFileModification(t *testing.T) {
 		t.Error("Hash should be different after file modification")
 	}
 
-	// Total hash should also be different
-	if result1.TotalHash == result2.TotalHash {
-		t.Error("Total hash should be different after file modification")
+	// Verify that files were recalculated due to cache invalidation
+	if len(result2.Files) == 0 {
+		t.Error("Should have calculated files after cache invalidation")
 	}
 }
 
@@ -261,8 +258,8 @@ func TestCalculator_ProbabilisticVerification(t *testing.T) {
 			}
 
 			// Results should be consistent
-			if result1.TotalHash != result2.TotalHash {
-				t.Errorf("Total hash inconsistent with probability %f", prob)
+			if result1.FileCount != result2.FileCount {
+				t.Errorf("File count inconsistent with probability %f", prob)
 			}
 		})
 	}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -122,8 +122,8 @@ func TestCalculateDirectory(t *testing.T) {
 		t.Fatalf("CalculateDirectory() second call error = %v", err)
 	}
 
-	if result.TotalHash != result2.TotalHash {
-		t.Error("TotalHash should be deterministic")
+	if result.FileCount != result2.FileCount {
+		t.Error("FileCount should be deterministic")
 	}
 
 	// Check file order is consistent
@@ -572,11 +572,7 @@ func TestSymlinkHandling(t *testing.T) {
 			t.Fatalf("Failed to calculate hash for symlink directory: %v", err)
 		}
 
-		// Both should produce the same hash
-		if realResult.TotalHash != symlinkResult.TotalHash {
-			t.Error("Hash for real directory and symlink should be identical")
-		}
-
+		// Both should produce the same file count
 		if realResult.FileCount != symlinkResult.FileCount {
 			t.Errorf("File count mismatch: real=%d, symlink=%d", realResult.FileCount, symlinkResult.FileCount)
 		}
@@ -685,7 +681,7 @@ func TestParallelCalculation(t *testing.T) {
 		t.Fatalf("CalculateDirectory() second call error = %v", err)
 	}
 
-	if result.TotalHash != result2.TotalHash {
+	if result.FileCount != result2.FileCount {
 		t.Error("Parallel processing should produce deterministic results")
 	}
 }
@@ -727,9 +723,6 @@ func TestRateLimitedCalculation(t *testing.T) {
 	}
 
 	// Results should be identical
-	if result1.TotalHash != result2.TotalHash {
-		t.Error("Rate limited calculation should produce same hash")
-	}
 
 	if result1.FileCount != result2.FileCount {
 		t.Errorf("File count mismatch: %d vs %d", result1.FileCount, result2.FileCount)

--- a/internal/hash/symlink_test.go
+++ b/internal/hash/symlink_test.go
@@ -536,51 +536,6 @@ func TestSymlinkExcludePatterns(t *testing.T) {
 	}
 }
 
-func TestCalculateTotalHashWithSymlinks(t *testing.T) {
-	calc := NewCalculator(1)
-
-	files := []FileInfo{
-		{
-			Path:      "file1.txt",
-			Hash:      "hash1",
-			Size:      100,
-			IsSymlink: false,
-		},
-		{
-			Path:       "link1",
-			Hash:       "hash2",
-			Size:       0,
-			IsSymlink:  true,
-			LinkTarget: "file1.txt",
-		},
-		{
-			Path:      "file2.txt",
-			Hash:      "hash3",
-			Size:      200,
-			IsSymlink: false,
-		},
-	}
-
-	totalHash := calc.calculateTotalHash(files)
-	if totalHash == "" {
-		t.Error("Total hash should not be empty")
-	}
-
-	// Ensure deterministic hash
-	totalHash2 := calc.calculateTotalHash(files)
-	if totalHash != totalHash2 {
-		t.Error("Total hash should be deterministic")
-	}
-
-	// Change symlink target should change total hash
-	files[1].LinkTarget = "different.txt"
-	files[1].Hash = "hash2_modified"
-	totalHash3 := calc.calculateTotalHash(files)
-	if totalHash == totalHash3 {
-		t.Error("Total hash should change when symlink target changes")
-	}
-}
-
 func TestParallelSymlinkProcessing(t *testing.T) {
 	tempDir := t.TempDir()
 	ctx := context.Background()

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -15,7 +15,6 @@ import (
 // Manifest represents the complete manifest structure
 type Manifest struct {
 	Version     string          `json:"version"`
-	TotalHash   string          `json:"total_hash"`
 	FileCount   int             `json:"file_count"`
 	GeneratedAt string          `json:"generated_at"`
 	Excludes    []string        `json:"excludes,omitempty"`
@@ -52,7 +51,6 @@ func (g *Generator) Generate(ctx context.Context, targetDir string, excludes []s
 	// Create manifest
 	manifest := &Manifest{
 		Version:     "1.0",
-		TotalHash:   result.TotalHash,
 		FileCount:   result.FileCount,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Excludes:    excludes,
@@ -193,12 +191,7 @@ func (m *Manifest) verifyWithCalculator(ctx context.Context, targetDir string, c
 		return fmt.Errorf("failed to calculate current state: %w", err)
 	}
 
-	// Quick check with total hash
-	if m.TotalHash == currentResult.TotalHash {
-		return nil // All files are intact
-	}
-
-	// Detailed comparison with file type and size checking
+	// Compare file hashes
 	manifestMap := make(map[string]hash.FileInfo)
 	for _, f := range m.Files {
 		manifestMap[f.Path] = f
@@ -268,10 +261,9 @@ func (m *Manifest) verifyWithCalculator(ctx context.Context, targetDir string, c
 // GetSummary returns a summary of the manifest
 func (m *Manifest) GetSummary() string {
 	return fmt.Sprintf(
-		"Version: %s\nGenerated: %s\nTotal Hash: %s\nFile Count: %d",
+		"Version: %s\nGenerated: %s\nFile Count: %d",
 		m.Version,
 		m.GeneratedAt,
-		m.TotalHash,
 		m.FileCount,
 	)
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -30,10 +30,6 @@ func TestGenerateManifest(t *testing.T) {
 		t.Errorf("Version = %v, want 1.0", manifest.Version)
 	}
 
-	if manifest.TotalHash == "" {
-		t.Error("TotalHash should not be empty")
-	}
-
 	if manifest.FileCount == 0 {
 		t.Error("FileCount should be greater than 0")
 	}
@@ -53,7 +49,6 @@ func TestSaveAndLoadManifest(t *testing.T) {
 	// Create a test manifest
 	manifest := &Manifest{
 		Version:     "1.0",
-		TotalHash:   "abc123def456",
 		FileCount:   2,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Files: []hash.FileInfo{
@@ -79,9 +74,6 @@ func TestSaveAndLoadManifest(t *testing.T) {
 		}
 
 		// Compare
-		if loaded.TotalHash != manifest.TotalHash {
-			t.Errorf("TotalHash = %v, want %v", loaded.TotalHash, manifest.TotalHash)
-		}
 
 		if loaded.FileCount != manifest.FileCount {
 			t.Errorf("FileCount = %d, want %d", loaded.FileCount, manifest.FileCount)
@@ -109,8 +101,12 @@ func TestSaveAndLoadManifest(t *testing.T) {
 		}
 
 		// Compare
-		if loaded.TotalHash != manifest.TotalHash {
-			t.Errorf("TotalHash = %v, want %v", loaded.TotalHash, manifest.TotalHash)
+		if loaded.FileCount != manifest.FileCount {
+			t.Errorf("FileCount = %d, want %d", loaded.FileCount, manifest.FileCount)
+		}
+
+		if len(loaded.Files) != len(manifest.Files) {
+			t.Errorf("Files length = %d, want %d", len(loaded.Files), len(manifest.Files))
 		}
 	})
 }
@@ -118,7 +114,6 @@ func TestSaveAndLoadManifest(t *testing.T) {
 func TestManifestJSON(t *testing.T) {
 	manifest := &Manifest{
 		Version:     "1.0",
-		TotalHash:   "test-hash",
 		FileCount:   1,
 		GeneratedAt: "2024-01-01T00:00:00Z",
 		Files: []hash.FileInfo{
@@ -136,7 +131,6 @@ func TestManifestJSON(t *testing.T) {
 	jsonStr := string(data)
 	expectedFields := []string{
 		`"version": "1.0"`,
-		`"total_hash": "test-hash"`,
 		`"file_count": 1`,
 		`"generated_at": "2024-01-01T00:00:00Z"`,
 		`"path": "test.txt"`,
@@ -157,8 +151,8 @@ func TestManifestJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	if loaded.TotalHash != manifest.TotalHash {
-		t.Errorf("Unmarshaled TotalHash = %v, want %v", loaded.TotalHash, manifest.TotalHash)
+	if loaded.FileCount != manifest.FileCount {
+		t.Errorf("Unmarshaled FileCount = %v, want %v", loaded.FileCount, manifest.FileCount)
 	}
 }
 
@@ -197,7 +191,6 @@ func TestManifestVerify(t *testing.T) {
 func TestGetSummary(t *testing.T) {
 	manifest := &Manifest{
 		Version:     "1.0",
-		TotalHash:   "abc123",
 		FileCount:   10,
 		GeneratedAt: "2024-01-01T00:00:00Z",
 	}
@@ -207,7 +200,6 @@ func TestGetSummary(t *testing.T) {
 	expectedParts := []string{
 		"Version: 1.0",
 		"Generated: 2024-01-01T00:00:00Z",
-		"Total Hash: abc123",
 		"File Count: 10",
 	}
 
@@ -422,9 +414,6 @@ func TestGeneratorWithRateLimit(t *testing.T) {
 	}
 
 	// Results should be identical
-	if manifest1.TotalHash != manifest2.TotalHash {
-		t.Error("Rate limited generator should produce same hash")
-	}
 
 	if manifest1.FileCount != manifest2.FileCount {
 		t.Errorf("File count mismatch: %d vs %d", manifest1.FileCount, manifest2.FileCount)

--- a/internal/manifest/symlink_spoof_test.go
+++ b/internal/manifest/symlink_spoof_test.go
@@ -191,8 +191,7 @@ func TestSymlinkSpoofingPrevention(t *testing.T) {
 			}
 		}
 
-		// Manually modify the total hash to force detailed comparison
-		manifest4.TotalHash = "force_detailed_check"
+		// Force detailed comparison by checking file modifications
 
 		// Verification should fail due to size difference
 		// (Now we check size for both symlinks and regular files for consistency)
@@ -239,7 +238,6 @@ func TestManifestVerifyWithTypeAndSize(t *testing.T) {
 	// Create a custom manifest to test verification logic
 	testManifest := &Manifest{
 		Version:     "1.0",
-		TotalHash:   "dummy", // Force detailed comparison
 		FileCount:   3,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Files: []hash.FileInfo{

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -101,7 +101,6 @@ func (f *Formatter) formatText(result *VerificationResult) error {
 type GenerationResult struct {
 	Success    bool   `json:"success"`
 	Timestamp  string `json:"timestamp"`
-	TotalHash  string `json:"total_hash"`
 	FileCount  int    `json:"file_count"`
 	OutputPath string `json:"output_path,omitempty"`
 	S3Key      string `json:"s3_key,omitempty"`
@@ -118,7 +117,6 @@ func (f *Formatter) FormatGeneration(result *GenerationResult, format string) er
 	case "text":
 		if result.Success {
 			fmt.Fprintln(f.writer, "✓ Manifest generated successfully")
-			fmt.Fprintf(f.writer, "  Total Hash: %s\n", result.TotalHash)
 			fmt.Fprintf(f.writer, "  File Count: %d\n", result.FileCount)
 			if result.OutputPath != "" {
 				fmt.Fprintf(f.writer, "  Output: %s\n", result.OutputPath)

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -97,19 +97,17 @@ func TestFormatGenerationResult(t *testing.T) {
 			result: &GenerationResult{
 				Success:    true,
 				Timestamp:  time.Now().UTC().Format(time.RFC3339),
-				TotalHash:  "abc123def456",
 				FileCount:  42,
 				OutputPath: "/tmp/manifest.json",
 			},
 			format:   "text",
-			contains: []string{"✓", "successfully", "abc123def456", "42", "/tmp/manifest.json"},
+			contains: []string{"✓", "successfully", "42", "/tmp/manifest.json"},
 		},
 		{
 			name: "text format with S3",
 			result: &GenerationResult{
 				Success:   true,
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
-				TotalHash: "xyz789",
 				FileCount: 10,
 				S3Key:     "production/app/manifest.json",
 			},
@@ -131,11 +129,10 @@ func TestFormatGenerationResult(t *testing.T) {
 			result: &GenerationResult{
 				Success:   true,
 				Timestamp: "2024-01-01T00:00:00Z",
-				TotalHash: "hash123",
 				FileCount: 5,
 			},
 			format:   "json",
-			contains: []string{`"success": true`, `"total_hash": "hash123"`, `"file_count": 5`},
+			contains: []string{`"success": true`, `"file_count": 5`},
 		},
 	}
 
@@ -217,7 +214,6 @@ func TestJSONMarshaling(t *testing.T) {
 		result := &GenerationResult{
 			Success:    true,
 			Timestamp:  "2024-01-01T00:00:00Z",
-			TotalHash:  "abc123",
 			FileCount:  5,
 			OutputPath: "/tmp/manifest.json",
 			S3Key:      "s3://bucket/key",
@@ -234,8 +230,8 @@ func TestJSONMarshaling(t *testing.T) {
 			t.Fatalf("json.Unmarshal() error = %v", err)
 		}
 
-		if unmarshaled.TotalHash != result.TotalHash {
-			t.Error("TotalHash field mismatch after unmarshaling")
+		if unmarshaled.FileCount != result.FileCount {
+			t.Error("FileCount field mismatch after unmarshaling")
 		}
 
 		if unmarshaled.S3Key != result.S3Key {

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -59,7 +59,6 @@ func (s *S3Storage) upload(key string, m *manifest.Manifest) error {
 		ContentType:          aws.String("application/json"),
 		ServerSideEncryption: aws.String("AES256"), // Enable server-side encryption
 		Metadata: map[string]*string{
-			"total-hash":   aws.String(m.TotalHash),
 			"generated-at": aws.String(m.GeneratedAt),
 			"file-count":   aws.String(fmt.Sprintf("%d", m.FileCount)),
 		},


### PR DESCRIPTION
This pull request removes the "total hash" field from the manifest and related hashing, output, and verification logic, shifting the focus to per-file hashes and file counts for integrity checks. The change simplifies the codebase and updates all related tests, data structures, and output formatting to eliminate reliance on the aggregate "total hash" value.

**Manifest and Hash Calculation Simplification:**
* Removed the `TotalHash` field from the `Manifest` and `Result` structs, and eliminated the calculation and usage of the total hash in manifest generation and hash calculation logic (`internal/manifest/manifest.go`, `internal/hash/hash.go`) [[1]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L18) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L36) [[3]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L232-L236) [[4]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L448-L461).
* Updated manifest verification to compare per-file hashes instead of using a quick check with the total hash (`internal/manifest/manifest.go`, `internal/hash/hash.go`) [[1]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L196-R194) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L521-R502) [[3]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L580-R556).

**Output and CLI Changes:**
* Removed the `TotalHash` field from output structs and CLI output, and updated the output formatting to no longer display or require the total hash (`internal/output/formatter.go`, `internal/cli/cli.go`) [[1]](diffhunk://#diff-3f85b170722e0a78e06ab10bca3146c9424e3155e8d608d54de142c19d49a12fL104) [[2]](diffhunk://#diff-3f85b170722e0a78e06ab10bca3146c9424e3155e8d608d54de142c19d49a12fL121) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL363).

**Test Suite Updates:**
* Refactored all tests to remove checks and dependencies on the total hash, replacing them with file count and per-file hash checks as appropriate (`internal/hash/hash_test.go`, `internal/hash/hash_cache_test.go`, `internal/hash/symlink_test.go`, `internal/manifest/manifest_test.go`, `internal/manifest/symlink_spoof_test.go`, `internal/output/formatter_test.go`, `internal/cli/cli_test.go`) [[1]](diffhunk://#diff-8b731275d2936d9c95d197886fa59d7b8cd161ae1fa4f0156ede14ca55ee6fd5L125-R126) [[2]](diffhunk://#diff-0bd499c89b0008d32649bee20022b1acbeb611c005e9f5a149e4ffbb2141d302L94-L96) [[3]](diffhunk://#diff-a2f51fc8d7da403f7b58563b71e6c9d12574b69732653987ee9e490283162b75L539-L583) [[4]](diffhunk://#diff-9fa6b9b6ac53923eed836a50409016adb3eff24f78aee49c601106b960ff57acL33-L36) [[5]](diffhunk://#diff-5397750c9674b751db86e2020967a5700f46249d441f4efb59a8c0e01625adceL194-R194) [[6]](diffhunk://#diff-20409426faa0417b14b96a656a1c75461b03d886e27fd74f2e469c9edd2eae1dL100-L112) [[7]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL157-R158).

**Documentation and Summary Adjustments:**
* Updated manifest summary and string formatting to remove references to the total hash (`internal/manifest/manifest.go`, `internal/manifest/manifest_test.go`) [[1]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L271-L274) [[2]](diffhunk://#diff-9fa6b9b6ac53923eed836a50409016adb3eff24f78aee49c601106b960ff57acL210).

**Code Cleanup:**
* Removed unused functions and fields related to total hash calculation and test helpers, streamlining the codebase (`internal/hash/hash.go`, `internal/manifest/manifest.go`, `internal/manifest/manifest_test.go`, `internal/hash/symlink_test.go`) [[1]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L448-L461) [[2]](diffhunk://#diff-690e7b459192b78ffe0159d8c095aa41c210de896d67b92b7bf548a8f585f371L55) [[3]](diffhunk://#diff-9fa6b9b6ac53923eed836a50409016adb3eff24f78aee49c601106b960ff57acL56) [[4]](diffhunk://#diff-a2f51fc8d7da403f7b58563b71e6c9d12574b69732653987ee9e490283162b75L539-L583).