### PR TITLE
Update systemd-run options: add --pipe and set CPUWeight=50

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,9 +557,9 @@ Alternatively, you can use systemd to control resource usage at the OS level:
 
 ```bash
 # Run with limited CPU and I/O priority (with cache support)
-systemd-run --quiet --wait --collect \
+systemd-run --quiet --wait --pipe --collect \
   -p Type=oneshot \
-  -p CPUQuota=25% -p CPUWeight=100 \
+  -p CPUQuota=25% -p CPUWeight=50 \
   -p PrivateTmp=no \
   /bin/bash -lc 'nice -n 10 ionice -c2 -n7 /usr/local/bin/kekkai verify \
     --s3-bucket my-manifests \
@@ -572,7 +572,7 @@ systemd-run --quiet --wait --collect \
 
 This approach provides more comprehensive resource control:
 - `CPUQuota=25%`: Limits CPU usage to 25%
-- `CPUWeight=100`: Sets CPU scheduling weight (lower priority)
+- `CPUWeight=50`: Sets CPU scheduling weight (lower priority)
 - `PrivateTmp=no`: Allows cache persistence in `/tmp` across runs
 - `nice -n 10`: Lower process priority
 - `ionice -c2 -n7`: Best-effort I/O scheduling with lowest priority
@@ -584,9 +584,9 @@ This approach provides more comprehensive resource control:
 
 ```bash
 # Alternative: Keep PrivateTmp=yes but use a custom cache directory
-systemd-run --quiet --wait --collect \
+systemd-run --quiet --wait --pipe --collect \
   -p Type=oneshot \
-  -p CPUQuota=25% -p CPUWeight=100 \
+  -p CPUQuota=25% -p CPUWeight=50 \
   -p PrivateTmp=yes \
   /bin/bash -lc 'nice -n 10 ionice -c2 -n7 /usr/local/bin/kekkai verify \
     --s3-bucket my-manifests \


### PR DESCRIPTION
This pull request updates the `README.md` to clarify and adjust the recommended `systemd-run` usage for controlling resource allocation. The main changes involve modifying the `CPUWeight` parameter for resource scheduling and ensuring the documentation accurately reflects these adjustments.

Resource control command updates:
* Changed the `systemd-run` example commands to use `--pipe` instead of just `--collect`, and updated `CPUWeight` from `100` to `50` for lower CPU scheduling priority. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L560-R562) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L587-R589)

Documentation accuracy:
* Updated the explanation of the `CPUWeight` parameter to reflect the new value (`50` instead of `100`) and its effect on CPU scheduling priority.