### PR TITLE
Update cache.md to note NFS limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ The cache file itself is protected with a hash to detect tampering.
 
 💡 **Cache Behavior:** By default, cache files are stored in the system temp directory (e.g., `/tmp` on Linux/macOS) and may be automatically cleaned by the system. This is intentional - the cache is designed to be ephemeral and will be recreated as needed for performance optimization.
 
+⚠️ **NFS Limitation:** Cache mode does not provide performance benefits on NFS-mounted directories. NFS clients may not reliably update ctime (change time) for metadata operations, causing cache misses even when files haven't actually changed. On NFS environments, disable cache mode (`--use-cache=false`) or expect minimal performance improvement. The ctime timestamp is crucial for cache security as it's difficult to forge, but NFS's distributed nature can cause inconsistencies in metadata timestamp updates.
+
 Note that application dependencies (vendor, node_modules) should still be verified as they are part of the deployed application.
 
 ### Q: System load is too high during verification

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -151,8 +151,7 @@ func (v *MetadataVerifier) CheckMetadata(path string) (metadataMatches bool) {
 	}
 
 	// ctime is the most important - it can't be easily forged
-	// Use platform-specific comparison to handle filesystem timestamp precision issues
-	if !isTimeEqualPlatform(ctime, entry.CTime) {
+	if !ctime.Equal(entry.CTime) {
 		return false
 	}
 

--- a/internal/cache/time_darwin.go
+++ b/internal/cache/time_darwin.go
@@ -16,9 +16,3 @@ func timeFromTimespec(ts syscall.Timespec) time.Time {
 func getCtime(stat *syscall.Stat_t) time.Time {
 	return timeFromTimespec(stat.Ctimespec)
 }
-
-// isTimeEqualPlatform implements Darwin-specific time comparison (exact)
-func isTimeEqualPlatform(t1, t2 time.Time) bool {
-	// Darwin APFS/HFS+ have nanosecond precision, use exact comparison
-	return t1.Equal(t2)
-}

--- a/internal/cache/time_linux.go
+++ b/internal/cache/time_linux.go
@@ -16,19 +16,3 @@ func timeFromTimespec(ts syscall.Timespec) time.Time {
 func getCtime(stat *syscall.Stat_t) time.Time {
 	return timeFromTimespec(stat.Ctim)
 }
-
-// isTimeEqualPlatform implements Linux-specific time comparison with tolerance
-func isTimeEqualPlatform(t1, t2 time.Time) bool {
-	if t1.Equal(t2) {
-		return true
-	}
-
-	// Linux filesystems may have microsecond precision issues
-	// Allow up to 1 microsecond tolerance
-	diff := t1.Sub(t2)
-	if diff < 0 {
-		diff = -diff
-	}
-
-	return diff <= 1*time.Microsecond
-}


### PR DESCRIPTION
This pull request simplifies the way cache file ctime (change time) is compared for cache validation, and updates the documentation to warn users about cache limitations on NFS-mounted directories. The main changes are grouped below:

Cache validation logic:

* Removed platform-specific ctime comparison functions (`isTimeEqualPlatform`) in favor of a direct `time.Time.Equal` comparison, eliminating microsecond tolerance on Linux and exact comparison on Darwin. This makes the cache validation logic simpler and more consistent across platforms. [[1]](diffhunk://#diff-113f0a3ddf486bd0f7ee93e06851fe642139355ce485bd7acd848729688962b2L154-R154) [[2]](diffhunk://#diff-040c1ea305c92ab03412528c281d32674de3c45c8a1d3357e0b054952a047421L19-L24) [[3]](diffhunk://#diff-f1c2aa3e7523f598d655221b148409c88289791627173ae70d9c05bc6c554f0fL19-L34)

Documentation updates:

* Added a warning to the `README.md` about the limitations of cache mode on NFS-mounted directories, explaining that unreliable ctime updates on NFS can lead to cache misses and reduced performance benefits.