### PR TITLE
refine directory skipping logic for exclude patterns, add tests

### DIFF
--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -278,6 +278,73 @@ func TestMatchExcludePatterns(t *testing.T) {
 	}
 }
 
+func TestShouldSkipDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		dirPath  string
+		excludes []string
+		expected bool
+	}{
+		{
+			name:     "skip logs directory with logs/**",
+			dirPath:  "logs",
+			excludes: []string{"logs/**"},
+			expected: true,
+		},
+		{
+			name:     "skip cache directory with cache/**",
+			dirPath:  "cache",
+			excludes: []string{"cache/**"},
+			expected: true,
+		},
+		{
+			name:     "skip nested logs directory with **/logs/**",
+			dirPath:  "app/logs",
+			excludes: []string{"**/logs/**"},
+			expected: true,
+		},
+		{
+			name:     "skip logs at root level with **/logs/**",
+			dirPath:  "logs",
+			excludes: []string{"**/logs/**"},
+			expected: true,
+		},
+		{
+			name:     "do not skip unrelated directory",
+			dirPath:  "src",
+			excludes: []string{"logs/**"},
+			expected: false,
+		},
+		{
+			name:     "skip everything with **",
+			dirPath:  "anything",
+			excludes: []string{"**"},
+			expected: true,
+		},
+		{
+			name:     "skip everything with **/*",
+			dirPath:  "anything",
+			excludes: []string{"**/*"},
+			expected: true,
+		},
+		{
+			name:     "no excludes",
+			dirPath:  "src",
+			excludes: nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSkipDirectory(tt.dirPath, tt.excludes)
+			if result != tt.expected {
+				t.Errorf("shouldSkipDirectory(%s) = %v, want %v", tt.dirPath, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestVerifyIntegrity(t *testing.T) {
 	calc := NewCalculator(0)
 


### PR DESCRIPTION
This pull request improves the directory exclusion logic in the file hashing process to optimize performance and ensure correctness when handling glob-style exclude patterns. The main change is the introduction of a new function to skip entire directory trees early when they match certain exclude patterns, along with corresponding updates to the traversal logic and new tests to verify the behavior.

**Directory exclusion improvements:**

* Updated the `collectFiles` function in `internal/hash/hash.go` to check for directory exclusion patterns before recursing into subdirectories, allowing entire directory trees to be skipped efficiently [[1]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L246-R246) [[2]](diffhunk://#diff-6c4d392224ff82238629b27a22da0330c691a265a8936018b459e55b1d1458e8L260-R269).
* Added a new `shouldSkipDirectory` function in `internal/hash/hash.go` that determines if a directory should be skipped based on patterns like `logs/**`, `**/logs/**`, or `**`, improving the handling of recursive and root-level exclusions.

**Testing enhancements:**

* Introduced a new test, `TestShouldSkipDirectory`, in `internal/hash/hash_test.go` to verify that the new directory skipping logic works correctly for various exclude pattern scenarios.