### PR TITLE
enforce strict cache file ownership and permission checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ If all metadata matches, it uses the cached hash. The `--verify-probability` opt
 - `0.1`: 10% chance to verify hash even with cache hit (default, good balance)
 - `1.0`: Always verify hash (most secure, no performance benefit)
 
-The cache file itself is protected with a hash to detect tampering.
+The cache file itself must be owned by the current user with `0600` permissions. Caches with missing integrity hashes, invalid integrity hashes, unexpected ownership, or unexpected permissions are ignored and rebuilt.
 
 ⚠️ **Security Note:** Cache mode is secure against casual tampering due to ctime checking, but a sophisticated attacker with root access could potentially forge metadata. The probabilistic verification adds an additional layer of security.
 
@@ -580,7 +580,7 @@ systemd-run --quiet --wait --pipe --collect \
 This approach provides more comprehensive resource control:
 - `CPUQuota=25%`: Limits CPU usage to 25%
 - `CPUWeight=50`: Sets CPU scheduling weight (lower priority)
-- `PrivateTmp=no`: Allows cache persistence in `/tmp` across runs
+- `PrivateTmp=no`: Required for the default `/tmp` cache to be reused by repeated one-shot `systemd-run` executions
 - `User=nobody`: Runs with minimal privileges for security
 - `nice -n 10`: Lower process priority
 - `ionice -c2 -n7`: Best-effort I/O scheduling with lowest priority
@@ -588,7 +588,7 @@ This approach provides more comprehensive resource control:
 - `--verify-probability 0.1`: 10% chance to verify hash even with cache hit
 - `--rate-limit 10485760`: Limits I/O to 10MB/s
 
-**Important**: The `PrivateTmp=no` setting is required when using `--use-cache` to ensure cache files persist between systemd-run executions. Without this, systemd creates an isolated `/tmp` directory for each run, preventing cache reuse. If you prefer stronger isolation, use `--cache-dir` to specify a persistent directory outside of `/tmp`:
+**Important**: `kekkai verify` is a one-shot command, not a long-running daemon. With `systemd-run`, `PrivateTmp=yes` gives each execution its own isolated `/tmp`, so the default temp-directory cache cannot be reused across runs. Use `PrivateTmp=no` with the default cache, or keep `PrivateTmp=yes` and set `--cache-dir` to a persistent directory outside `/tmp`:
 
 ```bash
 # Alternative: Keep PrivateTmp=yes but use a custom cache directory

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -73,8 +73,7 @@ func (v *MetadataVerifier) Load() error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	data, err := os.ReadFile(v.cachePath)
-	if err != nil {
+	if err := v.verifyCacheFileOwnership(); err != nil {
 		if os.IsNotExist(err) {
 			// Initialize empty cache
 			v.data = &MetadataCache{
@@ -84,6 +83,16 @@ func (v *MetadataVerifier) Load() error {
 			}
 			return nil
 		}
+		v.data = &MetadataCache{
+			Version:   "2.0",
+			CreatedAt: time.Now(),
+			Files:     make(map[string]MetadataEntry),
+		}
+		return err
+	}
+
+	data, err := os.ReadFile(v.cachePath)
+	if err != nil {
 		return fmt.Errorf("failed to read cache: %w", err)
 	}
 
@@ -325,16 +334,14 @@ func (v *MetadataVerifier) Remove() error {
 // verifyCacheIntegrity checks if the cache file has been tampered with
 func (v *MetadataVerifier) verifyCacheIntegrity(cache *MetadataCache) bool {
 	if cache == nil || cache.CacheHash == "" {
-		// No hash to verify
-		return true // Allow empty cache
+		return false
 	}
 
-	// Store and clear hash for verification
 	expectedHash := cache.CacheHash
+
 	tempCache := *cache
 	tempCache.CacheHash = ""
 
-	// Recalculate hash
 	data, err := json.Marshal(tempCache)
 	if err != nil {
 		return false
@@ -345,4 +352,21 @@ func (v *MetadataVerifier) verifyCacheIntegrity(cache *MetadataCache) bool {
 	actualHash := hex.EncodeToString(hasher.Sum(nil))
 
 	return actualHash == expectedHash
+}
+
+func (v *MetadataVerifier) verifyCacheFileOwnership() error {
+	info, err := os.Stat(v.cachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return err
+		}
+		return fmt.Errorf("failed to stat cache: %w", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		return fmt.Errorf("cache file %q has insecure permissions %o, starting fresh", v.cachePath, info.Mode().Perm())
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("cache file %q is not owned by the current user, starting fresh", v.cachePath)
+	}
+	return nil
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -276,7 +277,7 @@ func TestMetadataVerifier_CacheIntegrity(t *testing.T) {
 	// Manually corrupt the cache file
 	cacheFile := verifier.cachePath
 	corruptedData := []byte(`{"version":"2.0","cache_hash":"invalid","files":{}}`)
-	err = os.WriteFile(cacheFile, corruptedData, 0644)
+	err = os.WriteFile(cacheFile, corruptedData, 0600)
 	if err != nil {
 		t.Fatalf("Failed to write corrupted cache: %v", err)
 	}
@@ -291,6 +292,70 @@ func TestMetadataVerifier_CacheIntegrity(t *testing.T) {
 	// Data should still be initialized (fresh cache)
 	if verifier2.data == nil || verifier2.data.Version != "2.0" {
 		t.Error("Cache should be initialized even after corruption")
+	}
+}
+
+func TestMetadataVerifier_CacheIntegrityRejectsEmptyHash(t *testing.T) {
+	tempDir := t.TempDir()
+	targetDir := t.TempDir()
+	testFile := filepath.Join(targetDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test content"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	verifier := newTestVerifier(t, tempDir, "test", "app")
+	if err := verifier.Load(); err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if err := verifier.UpdateMetadata(testFile); err != nil {
+		t.Fatalf("UpdateMetadata() failed: %v", err)
+	}
+	if err := verifier.Save(); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	cacheFile := verifier.cachePath
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("Failed to read cache: %v", err)
+	}
+	var unsignedCache MetadataCache
+	if err := json.Unmarshal(data, &unsignedCache); err != nil {
+		t.Fatalf("Failed to unmarshal cache: %v", err)
+	}
+	unsignedCache.CacheHash = ""
+	unsignedData, err := json.Marshal(unsignedCache)
+	if err != nil {
+		t.Fatalf("Failed to marshal unsigned cache: %v", err)
+	}
+	if err := os.WriteFile(cacheFile, unsignedData, 0600); err != nil {
+		t.Fatalf("Failed to write unsigned cache: %v", err)
+	}
+
+	verifier2 := newTestVerifier(t, tempDir, "test", "app")
+	if err := verifier2.Load(); err == nil {
+		t.Fatal("Load() should reject cache with empty integrity hash")
+	}
+	if verifier2.CheckMetadata(testFile) {
+		t.Fatal("Unsigned cache entry should not be used")
+	}
+}
+
+func TestMetadataVerifier_IgnoresCacheWithInsecurePermissions(t *testing.T) {
+	tempDir := t.TempDir()
+
+	verifier := newTestVerifier(t, tempDir, "test", "app")
+	cacheFile := verifier.cachePath
+	cacheData := []byte(`{"version":"2.0","cache_hash":"invalid","files":{}}`)
+	if err := os.WriteFile(cacheFile, cacheData, 0644); err != nil {
+		t.Fatalf("Failed to write insecure cache: %v", err)
+	}
+
+	if err := verifier.Load(); err == nil {
+		t.Fatal("Load() should ignore cache with insecure permissions")
+	}
+	if verifier.data == nil || verifier.data.Version != "2.0" {
+		t.Fatal("Cache should be initialized fresh after insecure permissions")
 	}
 }
 


### PR DESCRIPTION
- Existing cache files with empty cache_hash are no longer accepted.
- Existing cache files not owned by the current user are ignored.
- Existing cache files with permissions other than 0600 are ignored.

This pull request strengthens the security and integrity checks for the cache file used by the metadata verifier. It enforces strict file ownership and permissions, ensures that unsigned or tampered caches are never trusted, and updates documentation and tests to reflect these changes.

**Security and integrity enforcement:**

* The cache file must now be owned by the current user and have `0600` permissions; caches with missing or invalid integrity hashes, wrong ownership, or insecure permissions are ignored and rebuilt. (`README.md`, `internal/cache/cache.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L548-R548) [[2]](diffhunk://#diff-113f0a3ddf486bd0f7ee93e06851fe642139355ce485bd7acd848729688962b2R356-R372)
* The integrity check now strictly rejects caches with missing integrity hashes, rather than allowing them. (`internal/cache/cache.go`)

**Cache loading logic:**

* On loading, the cache file's ownership and permissions are verified before reading; if verification fails, a new empty cache is initialized. (`internal/cache/cache.go`) [[1]](diffhunk://#diff-113f0a3ddf486bd0f7ee93e06851fe642139355ce485bd7acd848729688962b2L76-R76) [[2]](diffhunk://#diff-113f0a3ddf486bd0f7ee93e06851fe642139355ce485bd7acd848729688962b2R86-R95)

**Documentation updates:**

* Clarified in the documentation that the cache file must meet ownership and permission requirements, and explained the implications of `PrivateTmp` for cache reuse with `systemd-run`. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L548-R548) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L583-R591)

**Testing improvements:**

* Added tests to verify that caches with empty integrity hashes or insecure permissions are rejected and not used. (`internal/cache/cache_test.go`)
* Updated existing tests to use the correct file permissions for cache files. (`internal/cache/cache_test.go`)