### PR TITLE
Confine file hashing to the target directory with os.Root

### DIFF
--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -37,6 +37,11 @@ type Result struct {
 	FileCount int        `json:"file_count"`
 }
 
+// fileJob identifies a file by its slash-normalized path relative to the target directory.
+type fileJob struct {
+	relPath string
+}
+
 // Calculator handles hash calculation for files and directories
 type Calculator struct {
 	numWorkers        int
@@ -224,6 +229,12 @@ func (c *Calculator) CalculateDirectory(ctx context.Context, rootDir string, exc
 		return nil, fmt.Errorf("failed to resolve target directory: %w", err)
 	}
 
+	root, err := os.OpenRoot(resolvedDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open target directory: %w", err)
+	}
+	defer root.Close()
+
 	// Collect files
 	files, err := c.collectFiles(resolvedDir, excludes)
 	if err != nil {
@@ -231,7 +242,7 @@ func (c *Calculator) CalculateDirectory(ctx context.Context, rootDir string, exc
 	}
 
 	// Calculate hashes in parallel
-	fileInfos, err := c.calculateFileHashes(ctx, resolvedDir, files)
+	fileInfos, err := c.calculateFileHashes(ctx, root, resolvedDir, files)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate file hashes: %w", err)
 	}
@@ -247,9 +258,9 @@ func (c *Calculator) CalculateDirectory(ctx context.Context, rootDir string, exc
 	}, nil
 }
 
-// collectFiles walks the directory and collects files based on patterns
-func (c *Calculator) collectFiles(rootDir string, excludes []string) ([]string, error) {
-	files := make([]string, 0, 50) // Start with capacity for 50 files
+// collectFiles walks the directory and collects relative file paths based on patterns
+func (c *Calculator) collectFiles(rootDir string, excludes []string) ([]fileJob, error) {
+	files := make([]fileJob, 0, 50) // Start with capacity for 50 files
 
 	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -284,7 +295,7 @@ func (c *Calculator) collectFiles(rootDir string, excludes []string) ([]string, 
 			return nil
 		}
 
-		files = append(files, path)
+		files = append(files, fileJob{relPath: relPath})
 		return nil
 	})
 
@@ -292,12 +303,12 @@ func (c *Calculator) collectFiles(rootDir string, excludes []string) ([]string, 
 }
 
 // calculateFileHashes calculates hashes for multiple files in parallel
-func (c *Calculator) calculateFileHashes(ctx context.Context, rootDir string, files []string) ([]FileInfo, error) {
+func (c *Calculator) calculateFileHashes(ctx context.Context, root *os.Root, resolvedDir string, files []fileJob) ([]FileInfo, error) {
 	var wg sync.WaitGroup
 	// Use smaller buffer sizes to avoid excessive memory usage with large directories
 	// Buffer size is min(numWorkers * 2, 100) to balance between performance and memory
 	bufferSize := min(c.numWorkers*2, 100)
-	jobs := make(chan string, bufferSize)
+	jobs := make(chan fileJob, bufferSize)
 	results := make(chan FileInfo, bufferSize)
 	errors := make(chan error, bufferSize)
 
@@ -312,26 +323,26 @@ func (c *Calculator) calculateFileHashes(ctx context.Context, rootDir string, fi
 				select {
 				case <-ctx.Done():
 					return
-				case path, ok := <-jobs:
+				case job, ok := <-jobs:
 					if !ok {
 						return
 					}
 
-					info, err := os.Lstat(path) // Use Lstat to get symlink info
+					relPath := job.relPath
+
+					info, err := root.Lstat(relPath) // Use Lstat to get symlink info
 					if err != nil {
-						errors <- fmt.Errorf("failed to stat %s: %w", path, err)
+						errors <- fmt.Errorf("failed to stat %s: %w", relPath, err)
 						continue
 					}
-
-					relPath, _ := filepath.Rel(rootDir, path)
-					relPath = filepath.ToSlash(relPath)
 
 					var fileHash string
 					needHashCalculation := true
 
 					// Check cache if available (not for symlinks)
 					if c.metadataCache != nil && info.Mode()&os.ModeSymlink == 0 {
-						if c.metadataCache.CheckMetadata(path) {
+						absPath := filepath.Join(resolvedDir, filepath.FromSlash(relPath))
+						if c.metadataCache.CheckMetadata(absPath) {
 							// Metadata matches - decide whether to verify based on probability
 							if c.verifyProbability == 0 || rand.Float64() > c.verifyProbability {
 								// Skip hash calculation, use manifest hash if available
@@ -369,9 +380,9 @@ func (c *Calculator) calculateFileHashes(ctx context.Context, rootDir string, fi
 
 					// Handle symlinks or calculate hash if needed
 					if needHashCalculation && info.Mode()&os.ModeSymlink != 0 {
-						target, err := os.Readlink(path)
+						target, err := root.Readlink(relPath)
 						if err != nil {
-							errors <- fmt.Errorf("failed to read symlink %s: %w", path, err)
+							errors <- fmt.Errorf("failed to read symlink %s: %w", relPath, err)
 							continue
 						}
 
@@ -383,9 +394,9 @@ func (c *Calculator) calculateFileHashes(ctx context.Context, rootDir string, fi
 					} else if needHashCalculation {
 						// Regular file - calculate hash
 						var err error
-						fileHash, err = c.hashFileWithHasher(ctx, path, hasher, buf)
+						fileHash, err = c.hashFileWithHasher(ctx, root, relPath, hasher, buf)
 						if err != nil {
-							errors <- fmt.Errorf("failed to hash %s: %w", path, err)
+							errors <- fmt.Errorf("failed to hash %s: %w", relPath, err)
 							continue
 						}
 
@@ -400,7 +411,7 @@ func (c *Calculator) calculateFileHashes(ctx context.Context, rootDir string, fi
 						IsSymlink: info.Mode()&os.ModeSymlink != 0,
 						LinkTarget: func() string {
 							if info.Mode()&os.ModeSymlink != 0 {
-								target, _ := os.Readlink(path)
+								target, _ := root.Readlink(relPath)
 								return target
 							}
 							return ""
@@ -456,8 +467,8 @@ func (c *Calculator) calculateFileHashes(ctx context.Context, rootDir string, fi
 }
 
 // hashFileWithHasher calculates hash of a file using provided hasher and buffer (for reuse)
-func (c *Calculator) hashFileWithHasher(ctx context.Context, path string, hasher hash.Hash, buf []byte) (string, error) {
-	file, err := os.Open(path)
+func (c *Calculator) hashFileWithHasher(ctx context.Context, root *os.Root, relPath string, hasher hash.Hash, buf []byte) (string, error) {
+	file, err := root.Open(relPath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -82,26 +83,23 @@ func TestCalculateFileHash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create temporary file
-			tmpfile, err := os.CreateTemp("", "test")
+			tempDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			root, err := os.OpenRoot(tempDir)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.Remove(tmpfile.Name())
-
-			if _, err := tmpfile.Write([]byte(tt.content)); err != nil {
-				t.Fatal(err)
-			}
-			if err := tmpfile.Close(); err != nil {
-				t.Fatal(err)
-			}
+			defer root.Close()
 
 			// Calculate hash
 			calc := NewCalculator(0)
 			hasher := sha256.New()
 			buf := make([]byte, calc.bufferSize)
 			ctx := context.Background()
-			hash, err := calc.hashFileWithHasher(ctx, tmpfile.Name(), hasher, buf)
+			hash, err := calc.hashFileWithHasher(ctx, root, "test.txt", hasher, buf)
 			if err != nil {
 				t.Fatalf("hashFileWithHasher() error = %v", err)
 			}
@@ -150,6 +148,68 @@ func TestCalculateDirectory(t *testing.T) {
 		if result.Files[i].Hash != result2.Files[i].Hash {
 			t.Errorf("File hash mismatch for %s", result.Files[i].Path)
 		}
+	}
+}
+
+func TestCollectFilesReturnsRelativeJobs(t *testing.T) {
+	rootDir := t.TempDir()
+
+	testFiles := map[string]string{
+		"root.txt":             "root",
+		"nested/child.txt":     "nested",
+		"excluded/ignored.txt": "excluded",
+	}
+	for relPath, content := range testFiles {
+		path := filepath.Join(rootDir, filepath.FromSlash(relPath))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	calc := NewCalculator(2)
+	jobs, err := calc.collectFiles(rootDir, []string{"excluded/**"})
+	if err != nil {
+		t.Fatalf("collectFiles() error = %v", err)
+	}
+
+	relPaths := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		if filepath.IsAbs(job.relPath) {
+			t.Errorf("collectFiles() returned absolute path %q", job.relPath)
+		}
+		if strings.Contains(job.relPath, `\`) {
+			t.Errorf("collectFiles() returned non-normalized path %q", job.relPath)
+		}
+		relPaths = append(relPaths, job.relPath)
+	}
+	slices.Sort(relPaths)
+
+	expectedPaths := []string{"nested/child.txt", "root.txt"}
+	if !slices.Equal(relPaths, expectedPaths) {
+		t.Fatalf("collectFiles() paths = %v, want %v", relPaths, expectedPaths)
+	}
+
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	fileInfos, err := calc.calculateFileHashes(context.Background(), root, rootDir, jobs)
+	if err != nil {
+		t.Fatalf("calculateFileHashes() error = %v", err)
+	}
+
+	resultPaths := make([]string, 0, len(fileInfos))
+	for _, fileInfo := range fileInfos {
+		resultPaths = append(resultPaths, fileInfo.Path)
+	}
+	slices.Sort(resultPaths)
+	if !slices.Equal(resultPaths, expectedPaths) {
+		t.Errorf("calculateFileHashes() paths = %v, want %v", resultPaths, expectedPaths)
 	}
 }
 

--- a/internal/hash/root_test.go
+++ b/internal/hash/root_test.go
@@ -1,0 +1,141 @@
+package hash
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRootRejectsEscapingFileJobs(t *testing.T) {
+	parentDir := t.TempDir()
+	targetDir := filepath.Join(parentDir, "target")
+	if err := os.Mkdir(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "inside.txt"), []byte("inside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentDir, "outside.txt"), []byte("outside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := os.OpenRoot(targetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	calc := NewCalculator(1)
+	tests := []struct {
+		name    string
+		relPath string
+	}{
+		{
+			name:    "parent traversal",
+			relPath: "../outside.txt",
+		},
+		{
+			name:    "absolute path",
+			relPath: filepath.ToSlash(filepath.Join(targetDir, "inside.txt")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobs := []fileJob{{relPath: tt.relPath}}
+			if _, err := calc.calculateFileHashes(context.Background(), root, targetDir, jobs); err == nil {
+				t.Errorf("calculateFileHashes() accepted escaping path %q", tt.relPath)
+			}
+
+			hasher := sha256.New()
+			buf := make([]byte, calc.bufferSize)
+			if _, err := calc.hashFileWithHasher(context.Background(), root, tt.relPath, hasher, buf); err == nil {
+				t.Errorf("hashFileWithHasher() accepted escaping path %q", tt.relPath)
+			}
+		})
+	}
+}
+
+func TestRootSymlinksHashLinkTargetWithoutReadingContent(t *testing.T) {
+	parentDir := t.TempDir()
+	targetDir := filepath.Join(parentDir, "target")
+	if err := os.Mkdir(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	insidePath := filepath.Join(targetDir, "inside.txt")
+	outsidePath := filepath.Join(parentDir, "outside.txt")
+	if err := os.WriteFile(insidePath, []byte("inside content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outsidePath, []byte("outside content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	links := map[string]string{
+		"inside-link":  "inside.txt",
+		"outside-link": "../outside.txt",
+		"broken-link":  "missing.txt",
+	}
+	for name, target := range links {
+		if err := os.Symlink(target, filepath.Join(targetDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	calc := NewCalculator(2)
+	result, err := calc.CalculateDirectory(context.Background(), targetDir, []string{"inside.txt"})
+	if err != nil {
+		t.Fatalf("CalculateDirectory() error = %v", err)
+	}
+	assertSymlinkHashes(t, result, links)
+
+	if err := os.WriteFile(insidePath, []byte("changed inside content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outsidePath, []byte("changed outside content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err = calc.CalculateDirectory(context.Background(), targetDir, []string{"inside.txt"})
+	if err != nil {
+		t.Fatalf("CalculateDirectory() after target content changes error = %v", err)
+	}
+	assertSymlinkHashes(t, result, links)
+}
+
+func assertSymlinkHashes(t *testing.T, result *Result, links map[string]string) {
+	t.Helper()
+
+	if result.FileCount != len(links) {
+		t.Fatalf("FileCount = %d, want %d", result.FileCount, len(links))
+	}
+
+	files := make(map[string]FileInfo, len(result.Files))
+	for _, file := range result.Files {
+		files[file.Path] = file
+	}
+
+	for name, target := range links {
+		file, ok := files[name]
+		if !ok {
+			t.Errorf("symlink %q not found", name)
+			continue
+		}
+		if !file.IsSymlink {
+			t.Errorf("%q is not marked as a symlink", name)
+		}
+		if file.LinkTarget != target {
+			t.Errorf("%q LinkTarget = %q, want %q", name, file.LinkTarget, target)
+		}
+
+		sum := sha256.Sum256([]byte("symlink:" + target))
+		expectedHash := hex.EncodeToString(sum[:])
+		if file.Hash != expectedHash {
+			t.Errorf("%q Hash = %q, want %q", name, file.Hash, expectedHash)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved directory hashing to operate within the selected directory scope.
  * Added stronger validation to prevent file path traversal or escaping the selected location.
  * Enhanced symbolic link handling: symlink hashes are based on the link target (including broken links) without reading target contents.
* **Tests**
  * Expanded coverage to verify relative path handling, root boundary enforcement, and consistent symlink hashing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->